### PR TITLE
Frame EVM balances

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4839,6 +4839,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-evm-balances"
+version = "1.0.0-dev"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "log",
+ "mockall",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-evm-chain-id"
 version = "1.0.0-dev"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4842,10 +4842,13 @@ dependencies = [
 name = "pallet-evm-balances"
 version = "1.0.0-dev"
 dependencies = [
+ "fp-evm",
  "frame-support",
  "frame-system",
  "log",
- "mockall",
+ "pallet-evm",
+ "pallet-evm-system",
+ "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
  "sp-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
 	"frame/dynamic-fee",
 	"frame/ethereum",
 	"frame/evm",
+	"frame/evm-balances",
 	"frame/evm-chain-id",
 	"frame/evm-system",
 	"frame/hotfix-sufficients",
@@ -137,6 +138,7 @@ pallet-base-fee = { version = "1.0.0", path = "frame/base-fee", default-features
 pallet-dynamic-fee = { version = "4.0.0-dev", path = "frame/dynamic-fee", default-features = false }
 pallet-ethereum = { version = "4.0.0-dev", path = "frame/ethereum", default-features = false }
 pallet-evm = { version = "6.0.0-dev", path = "frame/evm", default-features = false }
+pallet-evm-balances = { version = "1.0.0-dev", path = "frame/evm-balances", default-features = false }
 pallet-evm-chain-id = { version = "1.0.0-dev", path = "frame/evm-chain-id", default-features = false }
 pallet-evm-system = { version = "1.0.0-dev", path = "frame/evm-system", default-features = false }
 pallet-evm-precompile-modexp = { version = "2.0.0-dev", path = "frame/evm/precompile/modexp", default-features = false }

--- a/frame/evm-balances/Cargo.toml
+++ b/frame/evm-balances/Cargo.toml
@@ -37,3 +37,7 @@ std = [
 	"sp-runtime/std",
 	"sp-std/std",
 ]
+try-runtime = [
+	"frame-support/try-runtime",
+	"frame-system/try-runtime",
+]

--- a/frame/evm-balances/Cargo.toml
+++ b/frame/evm-balances/Cargo.toml
@@ -21,7 +21,10 @@ sp-runtime = { workspace = true }
 sp-std = { workspace = true }
 
 [dev-dependencies]
-mockall = "0.11"
+fp-evm = { workspace = true }
+pallet-evm = { workspace = true }
+pallet-evm-system = { workspace = true }
+pallet-timestamp = { workspace = true }
 sp-core = { workspace = true }
 sp-io = { workspace = true }
 
@@ -34,8 +37,13 @@ std = [
 	# Substrate
 	"frame-support/std",
 	"frame-system/std",
+	"pallet-timestamp/std",
 	"sp-runtime/std",
 	"sp-std/std",
+	# Frontier
+	"fp-evm/std",
+	"pallet-evm/std",
+	"pallet-evm-system/std",
 ]
 try-runtime = [
 	"frame-support/try-runtime",

--- a/frame/evm-balances/Cargo.toml
+++ b/frame/evm-balances/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "pallet-evm-balances"
+version = "1.0.0-dev"
+license = "Apache-2.0"
+description = "FRAME EVM BALANCES pallet."
+authors = { workspace = true }
+edition = { workspace = true }
+repository = { workspace = true }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+log = { version = "0.4.17", default-features = false }
+scale-codec = { package = "parity-scale-codec", workspace = true }
+scale-info = { workspace = true }
+# Substrate
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+sp-runtime = { workspace = true }
+sp-std = { workspace = true }
+
+[dev-dependencies]
+mockall = "0.11"
+sp-core = { workspace = true }
+sp-io = { workspace = true }
+
+[features]
+default = ["std"]
+std = [
+	"log/std",
+	"scale-codec/std",
+	"scale-info/std",
+	# Substrate
+	"frame-support/std",
+	"frame-system/std",
+	"sp-runtime/std",
+	"sp-std/std",
+]

--- a/frame/evm-balances/src/account_data.rs
+++ b/frame/evm-balances/src/account_data.rs
@@ -25,22 +25,22 @@ impl<Balance: Copy> AccountData<Balance> {
 /// Simplified reasons for withdrawing balance.
 #[derive(Encode, Decode, Clone, Copy, PartialEq, Eq, RuntimeDebug, MaxEncodedLen, TypeInfo)]
 pub enum Reasons {
-    /// Paying system transaction fees.
-    Fee = 0,
-    /// Any reason other than paying system transaction fees.
-    Misc = 1,
-    /// Any reason at all.
-    All = 2,
+	/// Paying system transaction fees.
+	Fee = 0,
+	/// Any reason other than paying system transaction fees.
+	Misc = 1,
+	/// Any reason at all.
+	All = 2,
 }
 
 impl From<WithdrawReasons> for Reasons {
-    fn from(r: WithdrawReasons) -> Reasons {
-        if r == WithdrawReasons::TRANSACTION_PAYMENT {
-            Reasons::Fee
-        } else if r.contains(WithdrawReasons::TRANSACTION_PAYMENT) {
-            Reasons::All
-        } else {
-            Reasons::Misc
-        }
-    }
+	fn from(r: WithdrawReasons) -> Reasons {
+		if r == WithdrawReasons::TRANSACTION_PAYMENT {
+			Reasons::Fee
+		} else if r.contains(WithdrawReasons::TRANSACTION_PAYMENT) {
+			Reasons::All
+		} else {
+			Reasons::Misc
+		}
+	}
 }

--- a/frame/evm-balances/src/account_data.rs
+++ b/frame/evm-balances/src/account_data.rs
@@ -13,42 +13,13 @@ pub struct AccountData<Balance> {
 	/// This is the only balance that matters in terms of most operations on tokens. It
 	/// alone is used to determine the balance when in the contract execution environment.
 	pub free: Balance,
-	/// Balance which is reserved and may not be used at all.
-	///
-	/// This can still get slashed, but gets slashed last of all.
-	///
-	/// This balance is a 'reserve' balance that other subsystems use in order to set aside tokens
-	/// that are still 'owned' by the account holder, but which are suspendable.
-	/// This includes named reserve and unnamed reserve.
-	pub reserved: Balance,
-	/// The amount that `free` may not drop below when withdrawing for *anything except transaction
-	/// fee payment*.
-	pub misc_frozen: Balance,
-	/// The amount that `free` may not drop below when withdrawing specifically for transaction
-	/// fee payment.
-	pub fee_frozen: Balance,
 }
 
-impl<Balance: Saturating + Copy + Ord> AccountData<Balance> {
-	/// How much this account's balance can be reduced for the given `reasons`.
-	pub(crate) fn usable(&self, reasons: Reasons) -> Balance {
-		self.free.saturating_sub(self.frozen(reasons))
+impl<Balance: Copy> AccountData<Balance> {
+	/// The total balance in this account.
+	pub(crate) fn total(&self) -> Balance {
+		self.free
 	}
-
-    /// The amount that this account's free balance may not be reduced beyond for the given
-    /// `reasons`.
-    pub(crate) fn frozen(&self, reasons: Reasons) -> Balance {
-        match reasons {
-            Reasons::All => self.misc_frozen.max(self.fee_frozen),
-            Reasons::Misc => self.misc_frozen,
-            Reasons::Fee => self.fee_frozen,
-        }
-    }
-
-    /// The total balance in this account including any that is reserved and ignoring any frozen.
-    pub(crate) fn total(&self) -> Balance {
-        self.free.saturating_add(self.reserved)
-    }
 }
 
 /// Simplified reasons for withdrawing balance.

--- a/frame/evm-balances/src/account_data.rs
+++ b/frame/evm-balances/src/account_data.rs
@@ -1,0 +1,75 @@
+//! Account balances logic.
+
+use frame_support::traits::WithdrawReasons;
+
+use super::*;
+
+/// All balance information for an account.
+#[derive(Encode, Decode, Clone, PartialEq, Eq, Default, RuntimeDebug, MaxEncodedLen, TypeInfo)]
+pub struct AccountData<Balance> {
+	/// Non-reserved part of the balance. There may still be restrictions on this, but it is the
+	/// total pool what may in principle be transferred, reserved and used for tipping.
+	///
+	/// This is the only balance that matters in terms of most operations on tokens. It
+	/// alone is used to determine the balance when in the contract execution environment.
+	pub free: Balance,
+	/// Balance which is reserved and may not be used at all.
+	///
+	/// This can still get slashed, but gets slashed last of all.
+	///
+	/// This balance is a 'reserve' balance that other subsystems use in order to set aside tokens
+	/// that are still 'owned' by the account holder, but which are suspendable.
+	/// This includes named reserve and unnamed reserve.
+	pub reserved: Balance,
+	/// The amount that `free` may not drop below when withdrawing for *anything except transaction
+	/// fee payment*.
+	pub misc_frozen: Balance,
+	/// The amount that `free` may not drop below when withdrawing specifically for transaction
+	/// fee payment.
+	pub fee_frozen: Balance,
+}
+
+impl<Balance: Saturating + Copy + Ord> AccountData<Balance> {
+	/// How much this account's balance can be reduced for the given `reasons`.
+	pub(crate) fn usable(&self, reasons: Reasons) -> Balance {
+		self.free.saturating_sub(self.frozen(reasons))
+	}
+
+    /// The amount that this account's free balance may not be reduced beyond for the given
+    /// `reasons`.
+    pub(crate) fn frozen(&self, reasons: Reasons) -> Balance {
+        match reasons {
+            Reasons::All => self.misc_frozen.max(self.fee_frozen),
+            Reasons::Misc => self.misc_frozen,
+            Reasons::Fee => self.fee_frozen,
+        }
+    }
+
+    /// The total balance in this account including any that is reserved and ignoring any frozen.
+    pub(crate) fn total(&self) -> Balance {
+        self.free.saturating_add(self.reserved)
+    }
+}
+
+/// Simplified reasons for withdrawing balance.
+#[derive(Encode, Decode, Clone, Copy, PartialEq, Eq, RuntimeDebug, MaxEncodedLen, TypeInfo)]
+pub enum Reasons {
+    /// Paying system transaction fees.
+    Fee = 0,
+    /// Any reason other than paying system transaction fees.
+    Misc = 1,
+    /// Any reason at all.
+    All = 2,
+}
+
+impl From<WithdrawReasons> for Reasons {
+    fn from(r: WithdrawReasons) -> Reasons {
+        if r == WithdrawReasons::TRANSACTION_PAYMENT {
+            Reasons::Fee
+        } else if r.contains(WithdrawReasons::TRANSACTION_PAYMENT) {
+            Reasons::All
+        } else {
+            Reasons::Misc
+        }
+    }
+}

--- a/frame/evm-balances/src/imbalances.rs
+++ b/frame/evm-balances/src/imbalances.rs
@@ -1,0 +1,172 @@
+//! Imbalances implementation.
+
+use frame_support::traits::{SameOrOther, TryDrop};
+use sp_std::{cmp::Ordering, mem};
+
+use super::*;
+
+/// Opaque, move-only struct with private fields that serves as a token denoting that
+/// funds have been created without any equal and opposite accounting.
+#[must_use]
+#[derive(RuntimeDebug, PartialEq, Eq)]
+pub struct PositiveImbalance<T: Config<I>, I: 'static = ()>(T::Balance);
+
+impl<T: Config<I>, I: 'static> PositiveImbalance<T, I> {
+    /// Create a new positive imbalance from a balance.
+    pub fn new(amount: T::Balance) -> Self {
+        PositiveImbalance(amount)
+    }
+}
+
+/// Opaque, move-only struct with private fields that serves as a token denoting that
+/// funds have been destroyed without any equal and opposite accounting.
+#[must_use]
+#[derive(RuntimeDebug, PartialEq, Eq)]
+pub struct NegativeImbalance<T: Config<I>, I: 'static = ()>(T::Balance);
+
+impl<T: Config<I>, I: 'static> NegativeImbalance<T, I> {
+    /// Create a new negative imbalance from a balance.
+    pub fn new(amount: T::Balance) -> Self {
+        NegativeImbalance(amount)
+    }
+}
+
+impl<T: Config<I>, I: 'static> TryDrop for PositiveImbalance<T, I> {
+    fn try_drop(self) -> result::Result<(), Self> {
+        self.drop_zero()
+    }
+}
+
+impl<T: Config<I>, I: 'static> Default for PositiveImbalance<T, I> {
+    fn default() -> Self {
+        Self::zero()
+    }
+}
+
+impl<T: Config<I>, I: 'static> Imbalance<T::Balance> for PositiveImbalance<T, I> {
+    type Opposite = NegativeImbalance<T, I>;
+
+    fn zero() -> Self {
+        Self(Zero::zero())
+    }
+
+    fn drop_zero(self) -> result::Result<(), Self> {
+        if self.0.is_zero() {
+            Ok(())
+        } else {
+            Err(self)
+        }
+    }
+
+    fn split(self, amount: T::Balance) -> (Self, Self) {
+        let first = self.0.min(amount);
+        let second = self.0 - first;
+
+        mem::forget(self);
+        (Self(first), Self(second))
+    }
+
+    fn merge(mut self, other: Self) -> Self {
+        self.0 = self.0.saturating_add(other.0);
+        mem::forget(other);
+
+        self
+    }
+
+    fn subsume(&mut self, other: Self) {
+        self.0 = self.0.saturating_add(other.0);
+        mem::forget(other);
+    }
+
+    fn offset(self, other: Self::Opposite) -> SameOrOther<Self, Self::Opposite> {
+        let (a, b) = (self.0, other.0);
+        mem::forget((self, other));
+
+        match a.cmp(&b) {
+            Ordering::Greater => SameOrOther::Same(Self(a - b)),
+            Ordering::Less => SameOrOther::Other(NegativeImbalance::new(b - a)),
+            Ordering::Equal => SameOrOther::None,
+        }
+    }
+
+    fn peek(&self) -> T::Balance {
+        self.0
+    }
+}
+
+impl<T: Config<I>, I: 'static> TryDrop for NegativeImbalance<T, I> {
+    fn try_drop(self) -> result::Result<(), Self> {
+        self.drop_zero()
+    }
+}
+
+impl<T: Config<I>, I: 'static> Default for NegativeImbalance<T, I> {
+    fn default() -> Self {
+        Self::zero()
+    }
+}
+
+impl<T: Config<I>, I: 'static> Imbalance<T::Balance> for NegativeImbalance<T, I> {
+    type Opposite = PositiveImbalance<T, I>;
+
+    fn zero() -> Self {
+        Self(Zero::zero())
+    }
+
+    fn drop_zero(self) -> result::Result<(), Self> {
+        if self.0.is_zero() {
+            Ok(())
+        } else {
+            Err(self)
+        }
+    }
+
+    fn split(self, amount: T::Balance) -> (Self, Self) {
+        let first = self.0.min(amount);
+        let second = self.0 - first;
+
+        mem::forget(self);
+        (Self(first), Self(second))
+    }
+
+    fn merge(mut self, other: Self) -> Self {
+        self.0 = self.0.saturating_add(other.0);
+        mem::forget(other);
+
+        self
+    }
+
+    fn subsume(&mut self, other: Self) {
+        self.0 = self.0.saturating_add(other.0);
+        mem::forget(other);
+    }
+
+    fn offset(self, other: Self::Opposite) -> SameOrOther<Self, Self::Opposite> {
+        let (a, b) = (self.0, other.0);
+        mem::forget((self, other));
+
+        match a.cmp(&b) {
+            Ordering::Greater => SameOrOther::Same(Self(a - b)),
+            Ordering::Less => SameOrOther::Other(PositiveImbalance::new(b - a)),
+            Ordering::Equal => SameOrOther::None,
+        }
+    }
+
+    fn peek(&self) -> T::Balance {
+        self.0
+    }
+}
+
+impl<T: Config<I>, I: 'static> Drop for PositiveImbalance<T, I> {
+    /// Basic drop handler will just square up the total issuance.
+    fn drop(&mut self) {
+        TotalIssuance::<T, I>::mutate(|v| *v = v.saturating_add(self.0));
+    }
+}
+
+impl<T: Config<I>, I: 'static> Drop for NegativeImbalance<T, I> {
+    /// Basic drop handler will just square up the total issuance.
+    fn drop(&mut self) {
+        TotalIssuance::<T, I>::mutate(|v| *v = v.saturating_sub(self.0));
+    }
+}

--- a/frame/evm-balances/src/imbalances.rs
+++ b/frame/evm-balances/src/imbalances.rs
@@ -12,10 +12,10 @@ use super::*;
 pub struct PositiveImbalance<T: Config<I>, I: 'static = ()>(T::Balance);
 
 impl<T: Config<I>, I: 'static> PositiveImbalance<T, I> {
-    /// Create a new positive imbalance from a balance.
-    pub fn new(amount: T::Balance) -> Self {
-        PositiveImbalance(amount)
-    }
+	/// Create a new positive imbalance from a balance.
+	pub fn new(amount: T::Balance) -> Self {
+		PositiveImbalance(amount)
+	}
 }
 
 /// Opaque, move-only struct with private fields that serves as a token denoting that
@@ -25,148 +25,148 @@ impl<T: Config<I>, I: 'static> PositiveImbalance<T, I> {
 pub struct NegativeImbalance<T: Config<I>, I: 'static = ()>(T::Balance);
 
 impl<T: Config<I>, I: 'static> NegativeImbalance<T, I> {
-    /// Create a new negative imbalance from a balance.
-    pub fn new(amount: T::Balance) -> Self {
-        NegativeImbalance(amount)
-    }
+	/// Create a new negative imbalance from a balance.
+	pub fn new(amount: T::Balance) -> Self {
+		NegativeImbalance(amount)
+	}
 }
 
 impl<T: Config<I>, I: 'static> TryDrop for PositiveImbalance<T, I> {
-    fn try_drop(self) -> result::Result<(), Self> {
-        self.drop_zero()
-    }
+	fn try_drop(self) -> result::Result<(), Self> {
+		self.drop_zero()
+	}
 }
 
 impl<T: Config<I>, I: 'static> Default for PositiveImbalance<T, I> {
-    fn default() -> Self {
-        Self::zero()
-    }
+	fn default() -> Self {
+		Self::zero()
+	}
 }
 
 impl<T: Config<I>, I: 'static> Imbalance<T::Balance> for PositiveImbalance<T, I> {
-    type Opposite = NegativeImbalance<T, I>;
+	type Opposite = NegativeImbalance<T, I>;
 
-    fn zero() -> Self {
-        Self(Zero::zero())
-    }
+	fn zero() -> Self {
+		Self(Zero::zero())
+	}
 
-    fn drop_zero(self) -> result::Result<(), Self> {
-        if self.0.is_zero() {
-            Ok(())
-        } else {
-            Err(self)
-        }
-    }
+	fn drop_zero(self) -> result::Result<(), Self> {
+		if self.0.is_zero() {
+			Ok(())
+		} else {
+			Err(self)
+		}
+	}
 
-    fn split(self, amount: T::Balance) -> (Self, Self) {
-        let first = self.0.min(amount);
-        let second = self.0 - first;
+	fn split(self, amount: T::Balance) -> (Self, Self) {
+		let first = self.0.min(amount);
+		let second = self.0 - first;
 
-        mem::forget(self);
-        (Self(first), Self(second))
-    }
+		mem::forget(self);
+		(Self(first), Self(second))
+	}
 
-    fn merge(mut self, other: Self) -> Self {
-        self.0 = self.0.saturating_add(other.0);
-        mem::forget(other);
+	fn merge(mut self, other: Self) -> Self {
+		self.0 = self.0.saturating_add(other.0);
+		mem::forget(other);
 
-        self
-    }
+		self
+	}
 
-    fn subsume(&mut self, other: Self) {
-        self.0 = self.0.saturating_add(other.0);
-        mem::forget(other);
-    }
+	fn subsume(&mut self, other: Self) {
+		self.0 = self.0.saturating_add(other.0);
+		mem::forget(other);
+	}
 
-    fn offset(self, other: Self::Opposite) -> SameOrOther<Self, Self::Opposite> {
-        let (a, b) = (self.0, other.0);
-        mem::forget((self, other));
+	fn offset(self, other: Self::Opposite) -> SameOrOther<Self, Self::Opposite> {
+		let (a, b) = (self.0, other.0);
+		mem::forget((self, other));
 
-        match a.cmp(&b) {
-            Ordering::Greater => SameOrOther::Same(Self(a - b)),
-            Ordering::Less => SameOrOther::Other(NegativeImbalance::new(b - a)),
-            Ordering::Equal => SameOrOther::None,
-        }
-    }
+		match a.cmp(&b) {
+			Ordering::Greater => SameOrOther::Same(Self(a - b)),
+			Ordering::Less => SameOrOther::Other(NegativeImbalance::new(b - a)),
+			Ordering::Equal => SameOrOther::None,
+		}
+	}
 
-    fn peek(&self) -> T::Balance {
-        self.0
-    }
+	fn peek(&self) -> T::Balance {
+		self.0
+	}
 }
 
 impl<T: Config<I>, I: 'static> TryDrop for NegativeImbalance<T, I> {
-    fn try_drop(self) -> result::Result<(), Self> {
-        self.drop_zero()
-    }
+	fn try_drop(self) -> result::Result<(), Self> {
+		self.drop_zero()
+	}
 }
 
 impl<T: Config<I>, I: 'static> Default for NegativeImbalance<T, I> {
-    fn default() -> Self {
-        Self::zero()
-    }
+	fn default() -> Self {
+		Self::zero()
+	}
 }
 
 impl<T: Config<I>, I: 'static> Imbalance<T::Balance> for NegativeImbalance<T, I> {
-    type Opposite = PositiveImbalance<T, I>;
+	type Opposite = PositiveImbalance<T, I>;
 
-    fn zero() -> Self {
-        Self(Zero::zero())
-    }
+	fn zero() -> Self {
+		Self(Zero::zero())
+	}
 
-    fn drop_zero(self) -> result::Result<(), Self> {
-        if self.0.is_zero() {
-            Ok(())
-        } else {
-            Err(self)
-        }
-    }
+	fn drop_zero(self) -> result::Result<(), Self> {
+		if self.0.is_zero() {
+			Ok(())
+		} else {
+			Err(self)
+		}
+	}
 
-    fn split(self, amount: T::Balance) -> (Self, Self) {
-        let first = self.0.min(amount);
-        let second = self.0 - first;
+	fn split(self, amount: T::Balance) -> (Self, Self) {
+		let first = self.0.min(amount);
+		let second = self.0 - first;
 
-        mem::forget(self);
-        (Self(first), Self(second))
-    }
+		mem::forget(self);
+		(Self(first), Self(second))
+	}
 
-    fn merge(mut self, other: Self) -> Self {
-        self.0 = self.0.saturating_add(other.0);
-        mem::forget(other);
+	fn merge(mut self, other: Self) -> Self {
+		self.0 = self.0.saturating_add(other.0);
+		mem::forget(other);
 
-        self
-    }
+		self
+	}
 
-    fn subsume(&mut self, other: Self) {
-        self.0 = self.0.saturating_add(other.0);
-        mem::forget(other);
-    }
+	fn subsume(&mut self, other: Self) {
+		self.0 = self.0.saturating_add(other.0);
+		mem::forget(other);
+	}
 
-    fn offset(self, other: Self::Opposite) -> SameOrOther<Self, Self::Opposite> {
-        let (a, b) = (self.0, other.0);
-        mem::forget((self, other));
+	fn offset(self, other: Self::Opposite) -> SameOrOther<Self, Self::Opposite> {
+		let (a, b) = (self.0, other.0);
+		mem::forget((self, other));
 
-        match a.cmp(&b) {
-            Ordering::Greater => SameOrOther::Same(Self(a - b)),
-            Ordering::Less => SameOrOther::Other(PositiveImbalance::new(b - a)),
-            Ordering::Equal => SameOrOther::None,
-        }
-    }
+		match a.cmp(&b) {
+			Ordering::Greater => SameOrOther::Same(Self(a - b)),
+			Ordering::Less => SameOrOther::Other(PositiveImbalance::new(b - a)),
+			Ordering::Equal => SameOrOther::None,
+		}
+	}
 
-    fn peek(&self) -> T::Balance {
-        self.0
-    }
+	fn peek(&self) -> T::Balance {
+		self.0
+	}
 }
 
 impl<T: Config<I>, I: 'static> Drop for PositiveImbalance<T, I> {
-    /// Basic drop handler will just square up the total issuance.
-    fn drop(&mut self) {
-        TotalIssuance::<T, I>::mutate(|v| *v = v.saturating_add(self.0));
-    }
+	/// Basic drop handler will just square up the total issuance.
+	fn drop(&mut self) {
+		TotalIssuance::<T, I>::mutate(|v| *v = v.saturating_add(self.0));
+	}
 }
 
 impl<T: Config<I>, I: 'static> Drop for NegativeImbalance<T, I> {
-    /// Basic drop handler will just square up the total issuance.
-    fn drop(&mut self) {
-        TotalIssuance::<T, I>::mutate(|v| *v = v.saturating_sub(self.0));
-    }
+	/// Basic drop handler will just square up the total issuance.
+	fn drop(&mut self) {
+		TotalIssuance::<T, I>::mutate(|v| *v = v.saturating_sub(self.0));
+	}
 }

--- a/frame/evm-balances/src/lib.rs
+++ b/frame/evm-balances/src/lib.rs
@@ -20,14 +20,26 @@
 // Ensure we're `no_std` when compiling for Wasm.
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use frame_support::traits::{StorageVersion, OnUnbalanced, StoredMap, Imbalance};
-use sp_runtime::{traits::{One, Zero}, RuntimeDebug, DispatchResult, Saturating};
+use frame_support::{
+    ensure,
+    traits::{
+        fungible,
+        tokens::{DepositConsequence, WithdrawConsequence},
+        Currency, ExistenceRequirement,
+        ExistenceRequirement::AllowDeath,
+        Get, Imbalance, OnUnbalanced, SignedImbalance, StorageVersion, WithdrawReasons, StoredMap
+    },
+};
+use sp_runtime::{
+    traits::{Bounded, CheckedAdd, CheckedSub, MaybeSerializeDeserialize, Zero},
+    ArithmeticError, DispatchError, DispatchResult, RuntimeDebug, Saturating,
+};
 use scale_codec::{Codec, Encode, Decode, MaxEncodedLen};
 use scale_info::TypeInfo;
 use sp_std::{cmp, fmt::Debug, result};
 
 pub mod account_data;
-use account_data::AccountData;
+use account_data::{AccountData, Reasons};
 
 mod imbalances;
 pub use imbalances::{NegativeImbalance, PositiveImbalance};
@@ -111,6 +123,11 @@ pub mod pallet {
 	#[pallet::event]
     #[pallet::generate_deposit(pub(super) fn deposit_event)]
     pub enum Event<T: Config<I>, I: 'static = ()> {
+		/// An account was created with some free balance.
+        Endowed {
+            account: <T as Config<I>>::AccountId,
+            free_balance: T::Balance,
+        },
 		/// An account was removed whose balance was non-zero but below ExistentialDeposit,
         /// resulting in an outright loss.
         DustLost {
@@ -137,5 +154,198 @@ impl<T: Config<I>, I: 'static> Drop for DustCleaner<T, I> {
             });
             T::DustRemoval::on_unbalanced(dust);
         }
+    }
+}
+
+impl<T: Config<I>, I: 'static> Pallet<T, I> {
+	/// Get the free balance of an account.
+	pub fn free_balance(who: impl sp_std::borrow::Borrow<<T as Config<I>>::AccountId>) -> T::Balance {
+		Self::account(who.borrow()).free
+	}
+
+	/// Get the balance of an account that can be used for transfers, reservations, or any other
+	/// non-locking, non-transaction-fee activity. Will be at most `free_balance`.
+	pub fn usable_balance(who: impl sp_std::borrow::Borrow<<T as Config<I>>::AccountId>) -> T::Balance {
+		Self::account(who.borrow()).usable(Reasons::Misc)
+	}
+
+	/// Get the balance of an account that can be used for paying transaction fees (not tipping,
+	/// or any other kind of fees, though). Will be at most `free_balance`.
+	pub fn usable_balance_for_fees(who: impl sp_std::borrow::Borrow<<T as Config<I>>::AccountId>) -> T::Balance {
+		Self::account(who.borrow()).usable(Reasons::Fee)
+	}
+
+	/// Get the reserved balance of an account.
+	pub fn reserved_balance(who: impl sp_std::borrow::Borrow<<T as Config<I>>::AccountId>) -> T::Balance {
+		Self::account(who.borrow()).reserved
+	}
+
+    /// Get all balance information for an account.
+    fn account(who: &<T as Config<I>>::AccountId) -> AccountData<T::Balance> {
+        T::AccountStore::get(who)
+    }
+
+    /// Mutate an account to some new value, or delete it entirely with `None`. Will enforce
+    /// `ExistentialDeposit` law, annulling the account as needed. This will do nothing if the
+    /// result of `f` is an `Err`.
+    ///
+    /// NOTE: Doesn't do any preparatory work for creating a new account, so should only be used
+    /// when it is known that the account already exists.
+    ///
+    /// NOTE: LOW-LEVEL: This will not attempt to maintain total issuance. It is expected that
+    /// the caller will do this.
+    fn try_mutate_account<R, E: From<DispatchError>>(
+        who: &<T as Config<I>>::AccountId,
+        f: impl FnOnce(&mut AccountData<T::Balance>, bool) -> Result<R, E>,
+    ) -> Result<R, E> {
+        Self::try_mutate_account_with_dust(who, f).map(|(result, dust_cleaner)| {
+            drop(dust_cleaner);
+            result
+        })
+    }
+
+    /// Mutate an account to some new value, or delete it entirely with `None`. Will enforce
+    /// `ExistentialDeposit` law, annulling the account as needed. This will do nothing if the
+    /// result of `f` is an `Err`.
+    ///
+    /// It returns both the result from the closure, and an optional `DustCleaner` instance which
+    /// should be dropped once it is known that all nested mutates that could affect storage items
+    /// what the dust handler touches have completed.
+    ///
+    /// NOTE: Doesn't do any preparatory work for creating a new account, so should only be used
+    /// when it is known that the account already exists.
+    ///
+    /// NOTE: LOW-LEVEL: This will not attempt to maintain total issuance. It is expected that
+    /// the caller will do this.
+    fn try_mutate_account_with_dust<R, E: From<DispatchError>>(
+        who: &<T as Config<I>>::AccountId,
+        f: impl FnOnce(&mut AccountData<T::Balance>, bool) -> Result<R, E>,
+    ) -> Result<(R, DustCleaner<T, I>), E> {
+        let result = T::AccountStore::try_mutate_exists(who, |maybe_account| {
+            let is_new = maybe_account.is_none();
+            let mut account = maybe_account.take().unwrap_or_default();
+            f(&mut account, is_new).map(move |result| {
+                let maybe_endowed = if is_new { Some(account.free) } else { None };
+                let maybe_account_maybe_dust = Self::post_mutation(who, account);
+                *maybe_account = maybe_account_maybe_dust.0;
+                (maybe_endowed, maybe_account_maybe_dust.1, result)
+            })
+        });
+        result.map(|(maybe_endowed, maybe_dust, result)| {
+            if let Some(endowed) = maybe_endowed {
+                Self::deposit_event(Event::Endowed {
+                    account: who.clone(),
+                    free_balance: endowed,
+                });
+            }
+            let dust_cleaner = DustCleaner(maybe_dust.map(|dust| (who.clone(), dust)));
+            (result, dust_cleaner)
+        })
+    }
+
+    /// Handles any steps needed after mutating an account.
+    ///
+    /// This includes `DustRemoval` unbalancing, in the case than the `new` account's total balance
+    /// is non-zero but below ED.
+    ///
+    /// Returns two values:
+    /// - `Some` containing the the `new` account, iff the account has sufficient balance.
+    /// - `Some` containing the dust to be dropped, iff some dust should be dropped.
+    fn post_mutation(
+        _who: &<T as Config<I>>::AccountId,
+        new: AccountData<T::Balance>,
+    ) -> (
+        Option<AccountData<T::Balance>>,
+        Option<NegativeImbalance<T, I>>,
+    ) {
+        let total = new.total();
+        if total < T::ExistentialDeposit::get() {
+            if total.is_zero() {
+                (None, None)
+            } else {
+                (None, Some(NegativeImbalance::new(total)))
+            }
+        } else {
+            (Some(new), None)
+        }
+    }
+
+    fn deposit_consequence(
+        _who: &<T as Config<I>>::AccountId,
+        amount: T::Balance,
+        account: &AccountData<T::Balance>,
+        mint: bool,
+    ) -> DepositConsequence {
+        if amount.is_zero() {
+            return DepositConsequence::Success;
+        }
+
+        if mint && TotalIssuance::<T, I>::get().checked_add(&amount).is_none() {
+            return DepositConsequence::Overflow;
+        }
+
+        let new_total_balance = match account.total().checked_add(&amount) {
+            Some(x) => x,
+            None => return DepositConsequence::Overflow,
+        };
+
+        if new_total_balance < T::ExistentialDeposit::get() {
+            return DepositConsequence::BelowMinimum;
+        }
+
+        // NOTE: We assume that we are a provider, so don't need to do any checks in the
+        // case of account creation.
+
+        DepositConsequence::Success
+    }
+
+    fn withdraw_consequence(
+        _who: &<T as Config<I>>::AccountId,
+        amount: T::Balance,
+        account: &AccountData<T::Balance>,
+    ) -> WithdrawConsequence<T::Balance> {
+        if amount.is_zero() {
+            return WithdrawConsequence::Success;
+        }
+
+        if TotalIssuance::<T, I>::get().checked_sub(&amount).is_none() {
+            return WithdrawConsequence::Underflow;
+        }
+
+        let new_total_balance = match account.total().checked_sub(&amount) {
+            Some(x) => x,
+            None => return WithdrawConsequence::NoFunds,
+        };
+
+        // Provider restriction - total account balance cannot be reduced to zero if it cannot
+        // sustain the loss of a provider reference.
+        // NOTE: This assumes that the pallet is a provider (which is true). Is this ever changes,
+        // then this will need to adapt accordingly.
+        let ed = T::ExistentialDeposit::get();
+        let success = if new_total_balance < ed {
+            // ATTENTION. CHECK.
+            // if frame_system::Pallet::<T>::can_dec_provider(who) {
+            //     WithdrawConsequence::ReducedToZero(new_total_balance)
+            // } else {
+            //     return WithdrawConsequence::WouldDie;
+            // }
+            WithdrawConsequence::ReducedToZero(new_total_balance)
+        } else {
+            WithdrawConsequence::Success
+        };
+
+        // Enough free funds to have them be reduced.
+        let new_free_balance = match account.free.checked_sub(&amount) {
+            Some(b) => b,
+            None => return WithdrawConsequence::NoFunds,
+        };
+
+        // Eventual free funds must be no less than the frozen balance.
+        let min_balance = account.frozen(Reasons::All);
+        if new_free_balance < min_balance {
+            return WithdrawConsequence::Frozen;
+        }
+
+        success
     }
 }

--- a/frame/evm-balances/src/lib.rs
+++ b/frame/evm-balances/src/lib.rs
@@ -426,7 +426,7 @@ where
 		Self::account(who).free
 	}
 
-	// We don't have any existing withdrawal restrictions like locks and vesting balance.
+	// We don't have any existing withdrawal restrictions like locked and reserved balance.
 	fn ensure_can_withdraw(
 		_who: &<T as Config<I>>::AccountId,
 		_amount: T::Balance,

--- a/frame/evm-balances/src/lib.rs
+++ b/frame/evm-balances/src/lib.rs
@@ -38,8 +38,8 @@ use scale_codec::{Codec, Encode, Decode, MaxEncodedLen};
 use scale_info::TypeInfo;
 use sp_std::{cmp, fmt::Debug, result};
 
-pub mod account_data;
-use account_data::{AccountData, Reasons};
+mod account_data;
+pub use account_data::{AccountData, Reasons};
 
 mod imbalances;
 pub use imbalances::{NegativeImbalance, PositiveImbalance};

--- a/frame/evm-balances/src/lib.rs
+++ b/frame/evm-balances/src/lib.rs
@@ -20,13 +20,17 @@
 // Ensure we're `no_std` when compiling for Wasm.
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use frame_support::traits::{StorageVersion, OnUnbalanced, StoredMap};
-use sp_runtime::{traits::One, RuntimeDebug, DispatchResult, Saturating};
+use frame_support::traits::{StorageVersion, OnUnbalanced, StoredMap, Imbalance};
+use sp_runtime::{traits::{One, Zero}, RuntimeDebug, DispatchResult, Saturating};
 use scale_codec::{Codec, Encode, Decode, MaxEncodedLen};
 use scale_info::TypeInfo;
+use sp_std::{cmp, fmt::Debug, result};
 
 pub mod account_data;
 use account_data::AccountData;
+
+mod imbalances;
+pub use imbalances::{NegativeImbalance, PositiveImbalance};
 
 #[cfg(test)]
 mod mock;
@@ -90,6 +94,13 @@ pub mod pallet {
         /// Handler for the unbalanced reduction when removing a dust account.
         type DustRemoval: OnUnbalanced<NegativeImbalance<Self, I>>;
 	}
+
+	/// The total units issued.
+    #[pallet::storage]
+    #[pallet::getter(fn total_issuance)]
+    #[pallet::whitelist_storage]
+    pub type TotalIssuance<T: Config<I>, I: 'static = ()> = StorageValue<_, T::Balance, ValueQuery>;
+
 
 	#[pallet::event]
     #[pallet::generate_deposit(pub(super) fn deposit_event)]

--- a/frame/evm-balances/src/lib.rs
+++ b/frame/evm-balances/src/lib.rs
@@ -134,10 +134,48 @@ pub mod pallet {
             account: <T as Config<I>>::AccountId,
             amount: T::Balance,
         },
+		/// Transfer succeeded.
+        Transfer {
+            from: <T as Config<I>>::AccountId,
+            to: <T as Config<I>>::AccountId,
+            amount: T::Balance,
+        },
+		/// A balance was set by root.
+        BalanceSet {
+            who: <T as Config<I>>::AccountId,
+            free: T::Balance,
+            reserved: T::Balance,
+        },
+		/// Some amount was deposited (e.g. for transaction fees).
+        Deposit {
+            who: <T as Config<I>>::AccountId,
+            amount: T::Balance,
+        },
+        /// Some amount was withdrawn from the account (e.g. for transaction fees).
+        Withdraw {
+            who: <T as Config<I>>::AccountId,
+            amount: T::Balance,
+        },
+		/// Some amount was removed from the account (e.g. for misbehavior).
+        Slashed {
+            who: <T as Config<I>>::AccountId,
+            amount: T::Balance,
+        },
 	}
 
     #[pallet::error]
-    pub enum Error<T, I = ()> {}
+    pub enum Error<T, I = ()> {
+		/// Account liquidity restrictions prevent withdrawal
+        LiquidityRestrictions,
+		/// Balance too low to send value.
+        InsufficientBalance,
+        /// Value too low to create account due to existential deposit
+        ExistentialDeposit,
+		/// Transfer/payment would kill account
+        KeepAlive,
+		/// Beneficiary account must pre-exist
+        DeadAccount,
+	}
 }
 
 /// Removes a dust account whose balance was non-zero but below `ExistentialDeposit`.
@@ -322,17 +360,10 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
         // NOTE: This assumes that the pallet is a provider (which is true). Is this ever changes,
         // then this will need to adapt accordingly.
         let ed = T::ExistentialDeposit::get();
-        let success = if new_total_balance < ed {
-            // ATTENTION. CHECK.
-            // if frame_system::Pallet::<T>::can_dec_provider(who) {
-            //     WithdrawConsequence::ReducedToZero(new_total_balance)
-            // } else {
-            //     return WithdrawConsequence::WouldDie;
-            // }
-            WithdrawConsequence::ReducedToZero(new_total_balance)
-        } else {
-            WithdrawConsequence::Success
-        };
+        if new_total_balance < ed {
+            return WithdrawConsequence::WouldDie;
+        }
+		let success = WithdrawConsequence::Success;
 
         // Enough free funds to have them be reduced.
         let new_free_balance = match account.free.checked_sub(&amount) {
@@ -347,5 +378,397 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
         }
 
         success
+    }
+}
+
+impl<T: Config<I>, I: 'static> Currency<<T as Config<I>>::AccountId> for Pallet<T, I>
+where
+    T::Balance: MaybeSerializeDeserialize + Debug,
+{
+    type Balance = T::Balance;
+    type PositiveImbalance = PositiveImbalance<T, I>;
+    type NegativeImbalance = NegativeImbalance<T, I>;
+
+    fn total_balance(who: &<T as Config<I>>::AccountId) -> Self::Balance {
+        Self::account(who).total()
+    }
+
+    // Check if `value` amount of free balance can be slashed from `who`.
+    fn can_slash(who: &<T as Config<I>>::AccountId, value: Self::Balance) -> bool {
+        if value.is_zero() {
+            return true;
+        }
+        Self::free_balance(who) >= value
+    }
+
+    fn total_issuance() -> Self::Balance {
+        TotalIssuance::<T, I>::get()
+    }
+
+    fn active_issuance() -> Self::Balance {
+        <Self as fungible::Inspect<<T as Config<I>>::AccountId>>::active_issuance()
+    }
+
+    fn deactivate(amount: Self::Balance) {
+        InactiveIssuance::<T, I>::mutate(|b| b.saturating_accrue(amount));
+    }
+
+    fn reactivate(amount: Self::Balance) {
+        InactiveIssuance::<T, I>::mutate(|b| b.saturating_reduce(amount));
+    }
+
+    fn minimum_balance() -> Self::Balance {
+        T::ExistentialDeposit::get()
+    }
+
+    // Burn funds from the total issuance, returning a positive imbalance for the amount burned.
+    // Is a no-op if amount to be burned is zero.
+    fn burn(mut amount: Self::Balance) -> Self::PositiveImbalance {
+        if amount.is_zero() {
+            return PositiveImbalance::zero();
+        }
+        <TotalIssuance<T, I>>::mutate(|issued| {
+            *issued = issued.checked_sub(&amount).unwrap_or_else(|| {
+                amount = *issued;
+                Zero::zero()
+            });
+        });
+        PositiveImbalance::new(amount)
+    }
+
+    // Create new funds into the total issuance, returning a negative imbalance
+    // for the amount issued.
+    // Is a no-op if amount to be issued it zero.
+    fn issue(mut amount: Self::Balance) -> Self::NegativeImbalance {
+        if amount.is_zero() {
+            return NegativeImbalance::zero();
+        }
+        <TotalIssuance<T, I>>::mutate(|issued| {
+            *issued = issued.checked_add(&amount).unwrap_or_else(|| {
+                amount = Self::Balance::max_value() - *issued;
+                Self::Balance::max_value()
+            })
+        });
+        NegativeImbalance::new(amount)
+    }
+
+    fn free_balance(who: &<T as Config<I>>::AccountId) -> Self::Balance {
+        Self::account(who).free
+    }
+
+    // Ensure that an account can withdraw from their free balance given any existing withdrawal
+    // restrictions like locks and vesting balance.
+    // Is a no-op if amount to be withdrawn is zero.
+    //
+    // # <weight>
+    // Despite iterating over a list of locks, they are limited by the number of
+    // lock IDs, which means the number of runtime pallets that intend to use and create locks.
+    // # </weight>
+    fn ensure_can_withdraw(
+        who: &<T as Config<I>>::AccountId,
+        amount: T::Balance,
+        reasons: WithdrawReasons,
+        new_balance: T::Balance,
+    ) -> DispatchResult {
+        if amount.is_zero() {
+            return Ok(());
+        }
+        let min_balance = Self::account(who).frozen(reasons.into());
+        ensure!(
+            new_balance >= min_balance,
+            Error::<T, I>::LiquidityRestrictions
+        );
+        Ok(())
+    }
+
+    // Transfer some free balance from `transactor` to `dest`, respecting existence requirements.
+    // Is a no-op if value to be transferred is zero or the `transactor` is the same as `dest`.
+    fn transfer(
+        transactor: &<T as Config<I>>::AccountId,
+        dest: &<T as Config<I>>::AccountId,
+        value: Self::Balance,
+        existence_requirement: ExistenceRequirement,
+    ) -> DispatchResult {
+        if value.is_zero() || transactor == dest {
+            return Ok(());
+        }
+
+        Self::try_mutate_account_with_dust(
+            dest,
+            |to_account, _| -> Result<DustCleaner<T, I>, DispatchError> {
+                Self::try_mutate_account_with_dust(
+                    transactor,
+                    |from_account, _| -> DispatchResult {
+                        from_account.free = from_account
+                            .free
+                            .checked_sub(&value)
+                            .ok_or(Error::<T, I>::InsufficientBalance)?;
+
+                        // NOTE: total stake being stored in the same type means that this could
+                        // never overflow but better to be safe than sorry.
+                        to_account.free = to_account
+                            .free
+                            .checked_add(&value)
+                            .ok_or(ArithmeticError::Overflow)?;
+
+                        let ed = T::ExistentialDeposit::get();
+                        ensure!(to_account.total() >= ed, Error::<T, I>::ExistentialDeposit);
+
+                        Self::ensure_can_withdraw(
+                            transactor,
+                            value,
+                            WithdrawReasons::TRANSFER,
+                            from_account.free,
+                        )
+                        .map_err(|_| Error::<T, I>::LiquidityRestrictions)?;
+
+                        // TODO: This is over-conservative. There may now be other providers, and
+                        // this pallet may not even be a provider.
+                        let allow_death = existence_requirement == ExistenceRequirement::AllowDeath;
+                        ensure!(
+                            allow_death || from_account.total() >= ed,
+                            Error::<T, I>::KeepAlive
+                        );
+
+                        Ok(())
+                    },
+                )
+                .map(|(_, maybe_dust_cleaner)| maybe_dust_cleaner)
+            },
+        )?;
+
+        // Emit transfer event.
+        Self::deposit_event(Event::Transfer {
+            from: transactor.clone(),
+            to: dest.clone(),
+            amount: value,
+        });
+
+        Ok(())
+    }
+
+    /// Slash a target account `who`, returning the negative imbalance created and any left over
+    /// amount that could not be slashed.
+    ///
+    /// Is a no-op if `value` to be slashed is zero or the account does not exist.
+    ///
+    /// NOTE: `slash()` prefers free balance, but assumes that reserve balance can be drawn
+    /// from in extreme circumstances. `can_slash()` should be used prior to `slash()` to avoid
+    /// having to draw from reserved funds, however we err on the side of punishment if things are
+    /// inconsistent or `can_slash` wasn't used appropriately.
+    fn slash(
+        who: &<T as Config<I>>::AccountId,
+        value: Self::Balance,
+    ) -> (Self::NegativeImbalance, Self::Balance) {
+        if value.is_zero() {
+            return (NegativeImbalance::zero(), Zero::zero());
+        }
+        if Self::total_balance(who).is_zero() {
+            return (NegativeImbalance::zero(), value);
+        }
+
+        for attempt in 0..2 {
+            match Self::try_mutate_account(
+				who,
+				|account,
+				 _is_new|
+				 -> Result<(Self::NegativeImbalance, Self::Balance), DispatchError> {
+					// Best value is the most amount we can slash following liveness rules.
+					let best_value = match attempt {
+						// First attempt we try to slash the full amount, and see if liveness issues
+						// happen.
+						0 => value,
+						// If acting as a critical provider (i.e. first attempt failed), then slash
+						// as much as possible while leaving at least at ED.
+						_ => value.min(
+							(account.free + account.reserved)
+								.saturating_sub(T::ExistentialDeposit::get()),
+						),
+					};
+
+					let free_slash = cmp::min(account.free, best_value);
+					account.free -= free_slash; // Safe because of above check
+					let remaining_slash = best_value - free_slash; // Safe because of above check
+
+					if !remaining_slash.is_zero() {
+						// If we have remaining slash, take it from reserved balance.
+						let reserved_slash = cmp::min(account.reserved, remaining_slash);
+						account.reserved -= reserved_slash; // Safe because of above check
+						Ok((
+							NegativeImbalance::new(free_slash + reserved_slash),
+							value - free_slash - reserved_slash, /* Safe because value is gt or
+							                                      * eq total slashed */
+						))
+					} else {
+						// Else we are done!
+						Ok((
+							NegativeImbalance::new(free_slash),
+							value - free_slash, // Safe because value is gt or eq to total slashed
+						))
+					}
+				},
+			) {
+				Ok((imbalance, not_slashed)) => {
+					Self::deposit_event(Event::Slashed {
+						who: who.clone(),
+						amount: value.saturating_sub(not_slashed),
+					});
+					return (imbalance, not_slashed)
+				},
+				Err(_) => (),
+			}
+        }
+
+        // Should never get here. But we'll be defensive anyway.
+        (Self::NegativeImbalance::zero(), value)
+    }
+
+    /// Deposit some `value` into the free balance of an existing target account `who`.
+    ///
+    /// Is a no-op if the `value` to be deposited is zero.
+    fn deposit_into_existing(
+        who: &<T as Config<I>>::AccountId,
+        value: Self::Balance,
+    ) -> Result<Self::PositiveImbalance, DispatchError> {
+        if value.is_zero() {
+            return Ok(PositiveImbalance::zero());
+        }
+
+        Self::try_mutate_account(
+            who,
+            |account, is_new| -> Result<Self::PositiveImbalance, DispatchError> {
+                ensure!(!is_new, Error::<T, I>::DeadAccount);
+                account.free = account
+                    .free
+                    .checked_add(&value)
+                    .ok_or(ArithmeticError::Overflow)?;
+                Self::deposit_event(Event::Deposit {
+                    who: who.clone(),
+                    amount: value,
+                });
+                Ok(PositiveImbalance::new(value))
+            },
+        )
+    }
+
+    /// Deposit some `value` into the free balance of `who`, possibly creating a new account.
+    ///
+    /// This function is a no-op if:
+    /// - the `value` to be deposited is zero; or
+    /// - the `value` to be deposited is less than the required ED and the account does not yet
+    ///   exist; or
+    /// - the deposit would necessitate the account to exist and there are no provider references;
+    ///   or
+    /// - `value` is so large it would cause the balance of `who` to overflow.
+    fn deposit_creating(
+        who: &<T as Config<I>>::AccountId,
+        value: Self::Balance,
+    ) -> Self::PositiveImbalance {
+        if value.is_zero() {
+            return Self::PositiveImbalance::zero();
+        }
+
+        Self::try_mutate_account(
+            who,
+            |account, is_new| -> Result<Self::PositiveImbalance, DispatchError> {
+                let ed = T::ExistentialDeposit::get();
+                ensure!(value >= ed || !is_new, Error::<T, I>::ExistentialDeposit);
+
+                // defensive only: overflow should never happen, however in case it does, then this
+                // operation is a no-op.
+                account.free = match account.free.checked_add(&value) {
+                    Some(x) => x,
+                    None => return Ok(Self::PositiveImbalance::zero()),
+                };
+
+                Self::deposit_event(Event::Deposit {
+                    who: who.clone(),
+                    amount: value,
+                });
+                Ok(PositiveImbalance::new(value))
+            },
+        )
+        .unwrap_or_else(|_| Self::PositiveImbalance::zero())
+    }
+
+    /// Withdraw some free balance from an account, respecting existence requirements.
+    ///
+    /// Is a no-op if value to be withdrawn is zero.
+    fn withdraw(
+        who: &<T as Config<I>>::AccountId,
+        value: Self::Balance,
+        reasons: WithdrawReasons,
+        liveness: ExistenceRequirement,
+    ) -> result::Result<Self::NegativeImbalance, DispatchError> {
+        if value.is_zero() {
+            return Ok(NegativeImbalance::zero());
+        }
+
+        Self::try_mutate_account(
+            who,
+            |account, _| -> Result<Self::NegativeImbalance, DispatchError> {
+                let new_free_account = account
+                    .free
+                    .checked_sub(&value)
+                    .ok_or(Error::<T, I>::InsufficientBalance)?;
+
+                // bail if we need to keep the account alive and this would kill it.
+                let ed = T::ExistentialDeposit::get();
+                let would_be_dead = new_free_account + account.reserved < ed;
+                let would_kill = would_be_dead && account.free + account.reserved >= ed;
+                ensure!(
+                    liveness == AllowDeath || !would_kill,
+                    Error::<T, I>::KeepAlive
+                );
+
+                Self::ensure_can_withdraw(who, value, reasons, new_free_account)?;
+
+                account.free = new_free_account;
+
+                Self::deposit_event(Event::Withdraw {
+                    who: who.clone(),
+                    amount: value,
+                });
+                Ok(NegativeImbalance::new(value))
+            },
+        )
+    }
+
+    /// Force the new free balance of a target account `who` to some new value `balance`.
+    fn make_free_balance_be(
+        who: &<T as Config<I>>::AccountId,
+        value: Self::Balance,
+    ) -> SignedImbalance<Self::Balance, Self::PositiveImbalance> {
+        Self::try_mutate_account(
+			who,
+			|account,
+			 is_new|
+			 -> Result<SignedImbalance<Self::Balance, Self::PositiveImbalance>, DispatchError> {
+				let ed = T::ExistentialDeposit::get();
+				let total = value.saturating_add(account.reserved);
+				// If we're attempting to set an existing account to less than ED, then
+				// bypass the entire operation. It's a no-op if you follow it through, but
+				// since this is an instance where we might account for a negative imbalance
+				// (in the dust cleaner of set_account) before we account for its actual
+				// equal and opposite cause (returned as an Imbalance), then in the
+				// instance that there's no other accounts on the system at all, we might
+				// underflow the issuance and our arithmetic will be off.
+				ensure!(total >= ed || !is_new, Error::<T, I>::ExistentialDeposit);
+
+				let imbalance = if account.free <= value {
+					SignedImbalance::Positive(PositiveImbalance::new(value - account.free))
+				} else {
+					SignedImbalance::Negative(NegativeImbalance::new(account.free - value))
+				};
+				account.free = value;
+				Self::deposit_event(Event::BalanceSet {
+					who: who.clone(),
+					free: account.free,
+					reserved: account.reserved,
+				});
+				Ok(imbalance)
+			},
+		)
+		.unwrap_or_else(|_| SignedImbalance::Positive(Self::PositiveImbalance::zero()))
     }
 }

--- a/frame/evm-balances/src/lib.rs
+++ b/frame/evm-balances/src/lib.rs
@@ -20,9 +20,12 @@
 // Ensure we're `no_std` when compiling for Wasm.
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use sp_runtime::{traits::One, RuntimeDebug, DispatchResult};
+use sp_runtime::{traits::One, RuntimeDebug, DispatchResult, Saturating};
 use scale_codec::{Encode, Decode, MaxEncodedLen, FullCodec};
 use scale_info::TypeInfo;
+
+pub mod account_data;
+use account_data::AccountData;
 
 #[cfg(test)]
 mod mock;

--- a/frame/evm-balances/src/lib.rs
+++ b/frame/evm-balances/src/lib.rs
@@ -21,21 +21,21 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use frame_support::{
-    ensure,
-    traits::{
-        fungible,
-        tokens::{DepositConsequence, WithdrawConsequence},
-        Currency, ExistenceRequirement,
-        ExistenceRequirement::AllowDeath,
-        Get, Imbalance, OnUnbalanced, SignedImbalance, StorageVersion, WithdrawReasons, StoredMap
-    },
+	ensure,
+	traits::{
+		fungible,
+		tokens::{DepositConsequence, WithdrawConsequence},
+		Currency, ExistenceRequirement,
+		ExistenceRequirement::AllowDeath,
+		Get, Imbalance, OnUnbalanced, SignedImbalance, StorageVersion, StoredMap, WithdrawReasons,
+	},
 };
-use sp_runtime::{
-    traits::{Bounded, CheckedAdd, CheckedSub, MaybeSerializeDeserialize, Zero},
-    ArithmeticError, DispatchError, DispatchResult, RuntimeDebug, Saturating,
-};
-use scale_codec::{Codec, Encode, Decode, MaxEncodedLen};
+use scale_codec::{Codec, Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
+use sp_runtime::{
+	traits::{Bounded, CheckedAdd, CheckedSub, MaybeSerializeDeserialize, Zero},
+	ArithmeticError, DispatchError, DispatchResult, RuntimeDebug, Saturating,
+};
 use sp_std::{cmp, fmt::Debug, result};
 
 mod account_data;
@@ -59,20 +59,21 @@ pub mod pallet {
 	use super::*;
 	use frame_support::pallet_prelude::*;
 	use sp_runtime::{
-        traits::{AtLeast32BitUnsigned, MaybeDisplay},
-        FixedPointOperand,
-    };
+		traits::{AtLeast32BitUnsigned, MaybeDisplay},
+		FixedPointOperand,
+	};
 	use sp_std::fmt::Debug;
 
 	#[pallet::pallet]
-    #[pallet::storage_version(STORAGE_VERSION)]
-    #[pallet::generate_store(pub(super) trait Store)]
-    pub struct Pallet<T, I = ()>(PhantomData<(T, I)>);
+	#[pallet::storage_version(STORAGE_VERSION)]
+	#[pallet::generate_store(pub(super) trait Store)]
+	pub struct Pallet<T, I = ()>(PhantomData<(T, I)>);
 
 	#[pallet::config]
 	pub trait Config<I: 'static = ()>: frame_system::Config {
 		/// The overarching event type.
-		type RuntimeEvent: From<Event<Self, I>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+		type RuntimeEvent: From<Event<Self, I>>
+			+ IsType<<Self as frame_system::Config>::RuntimeEvent>;
 
 		/// The user account identifier type.
 		type AccountId: Parameter
@@ -84,441 +85,439 @@ pub mod pallet {
 			+ MaxEncodedLen;
 
 		/// The balance of an account.
-        type Balance: Parameter
-            + Member
-            + AtLeast32BitUnsigned
-            + Codec
-            + Default
-            + Copy
-            + MaybeSerializeDeserialize
-            + Debug
-            + MaxEncodedLen
-            + TypeInfo
-            + FixedPointOperand;
+		type Balance: Parameter
+			+ Member
+			+ AtLeast32BitUnsigned
+			+ Codec
+			+ Default
+			+ Copy
+			+ MaybeSerializeDeserialize
+			+ Debug
+			+ MaxEncodedLen
+			+ TypeInfo
+			+ FixedPointOperand;
 
 		/// The minimum amount required to keep an account open.
-        #[pallet::constant]
-        type ExistentialDeposit: Get<Self::Balance>;
+		#[pallet::constant]
+		type ExistentialDeposit: Get<Self::Balance>;
 
 		/// The means of storing the balances of an account.
 		type AccountStore: StoredMap<<Self as Config<I>>::AccountId, AccountData<Self::Balance>>;
 
-        /// Handler for the unbalanced reduction when removing a dust account.
-        type DustRemoval: OnUnbalanced<NegativeImbalance<Self, I>>;
+		/// Handler for the unbalanced reduction when removing a dust account.
+		type DustRemoval: OnUnbalanced<NegativeImbalance<Self, I>>;
 	}
 
 	/// The total units issued.
-    #[pallet::storage]
-    #[pallet::getter(fn total_issuance)]
-    #[pallet::whitelist_storage]
-    pub type TotalIssuance<T: Config<I>, I: 'static = ()> = StorageValue<_, T::Balance, ValueQuery>;
+	#[pallet::storage]
+	#[pallet::getter(fn total_issuance)]
+	#[pallet::whitelist_storage]
+	pub type TotalIssuance<T: Config<I>, I: 'static = ()> = StorageValue<_, T::Balance, ValueQuery>;
 
 	/// The total units of outstanding deactivated balance.
-    #[pallet::storage]
-    #[pallet::getter(fn inactive_issuance)]
-    #[pallet::whitelist_storage]
-    pub type InactiveIssuance<T: Config<I>, I: 'static = ()> =
-        StorageValue<_, T::Balance, ValueQuery>;
+	#[pallet::storage]
+	#[pallet::getter(fn inactive_issuance)]
+	#[pallet::whitelist_storage]
+	pub type InactiveIssuance<T: Config<I>, I: 'static = ()> =
+		StorageValue<_, T::Balance, ValueQuery>;
 
 	#[pallet::event]
-    #[pallet::generate_deposit(pub(super) fn deposit_event)]
-    pub enum Event<T: Config<I>, I: 'static = ()> {
+	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	pub enum Event<T: Config<I>, I: 'static = ()> {
 		/// An account was created with some free balance.
-        Endowed {
-            account: <T as Config<I>>::AccountId,
-            free_balance: T::Balance,
-        },
+		Endowed {
+			account: <T as Config<I>>::AccountId,
+			free_balance: T::Balance,
+		},
 		/// An account was removed whose balance was non-zero but below ExistentialDeposit,
-        /// resulting in an outright loss.
-        DustLost {
-            account: <T as Config<I>>::AccountId,
-            amount: T::Balance,
-        },
+		/// resulting in an outright loss.
+		DustLost {
+			account: <T as Config<I>>::AccountId,
+			amount: T::Balance,
+		},
 		/// Transfer succeeded.
-        Transfer {
-            from: <T as Config<I>>::AccountId,
-            to: <T as Config<I>>::AccountId,
-            amount: T::Balance,
-        },
+		Transfer {
+			from: <T as Config<I>>::AccountId,
+			to: <T as Config<I>>::AccountId,
+			amount: T::Balance,
+		},
 		/// A balance was set by root.
-        BalanceSet {
-            who: <T as Config<I>>::AccountId,
-            free: T::Balance,
-        },
+		BalanceSet {
+			who: <T as Config<I>>::AccountId,
+			free: T::Balance,
+		},
 		/// Some amount was deposited (e.g. for transaction fees).
-        Deposit {
-            who: <T as Config<I>>::AccountId,
-            amount: T::Balance,
-        },
-        /// Some amount was withdrawn from the account (e.g. for transaction fees).
-        Withdraw {
-            who: <T as Config<I>>::AccountId,
-            amount: T::Balance,
-        },
+		Deposit {
+			who: <T as Config<I>>::AccountId,
+			amount: T::Balance,
+		},
+		/// Some amount was withdrawn from the account (e.g. for transaction fees).
+		Withdraw {
+			who: <T as Config<I>>::AccountId,
+			amount: T::Balance,
+		},
 		/// Some amount was removed from the account (e.g. for misbehavior).
-        Slashed {
-            who: <T as Config<I>>::AccountId,
-            amount: T::Balance,
-        },
+		Slashed {
+			who: <T as Config<I>>::AccountId,
+			amount: T::Balance,
+		},
 	}
 
-    #[pallet::error]
-    pub enum Error<T, I = ()> {
+	#[pallet::error]
+	pub enum Error<T, I = ()> {
 		/// Account liquidity restrictions prevent withdrawal
-        LiquidityRestrictions,
+		LiquidityRestrictions,
 		/// Balance too low to send value.
-        InsufficientBalance,
-        /// Value too low to create account due to existential deposit
-        ExistentialDeposit,
+		InsufficientBalance,
+		/// Value too low to create account due to existential deposit
+		ExistentialDeposit,
 		/// Transfer/payment would kill account
-        KeepAlive,
+		KeepAlive,
 		/// Beneficiary account must pre-exist
-        DeadAccount,
+		DeadAccount,
 	}
 }
 
 /// Removes a dust account whose balance was non-zero but below `ExistentialDeposit`.
 pub struct DustCleaner<T: Config<I>, I: 'static = ()>(
-    Option<(<T as Config<I>>::AccountId, NegativeImbalance<T, I>)>,
+	Option<(<T as Config<I>>::AccountId, NegativeImbalance<T, I>)>,
 );
 
 impl<T: Config<I>, I: 'static> Drop for DustCleaner<T, I> {
-    fn drop(&mut self) {
-        if let Some((who, dust)) = self.0.take() {
-            Pallet::<T, I>::deposit_event(Event::DustLost {
-                account: who,
-                amount: dust.peek(),
-            });
-            T::DustRemoval::on_unbalanced(dust);
-        }
-    }
+	fn drop(&mut self) {
+		if let Some((who, dust)) = self.0.take() {
+			Pallet::<T, I>::deposit_event(Event::DustLost {
+				account: who,
+				amount: dust.peek(),
+			});
+			T::DustRemoval::on_unbalanced(dust);
+		}
+	}
 }
 
 impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	/// Get the free balance of an account.
-	pub fn free_balance(who: impl sp_std::borrow::Borrow<<T as Config<I>>::AccountId>) -> T::Balance {
+	pub fn free_balance(
+		who: impl sp_std::borrow::Borrow<<T as Config<I>>::AccountId>,
+	) -> T::Balance {
 		Self::account(who.borrow()).free
 	}
 
-    /// Get all data information for an account.
-    fn account(who: &<T as Config<I>>::AccountId) -> AccountData<T::Balance> {
-        T::AccountStore::get(who)
-    }
+	/// Get all data information for an account.
+	fn account(who: &<T as Config<I>>::AccountId) -> AccountData<T::Balance> {
+		T::AccountStore::get(who)
+	}
 
-    /// Mutate an account to some new value, or delete it entirely with `None`. Will enforce
-    /// `ExistentialDeposit` law, annulling the account as needed. This will do nothing if the
-    /// result of `f` is an `Err`.
-    ///
-    /// NOTE: Doesn't do any preparatory work for creating a new account, so should only be used
-    /// when it is known that the account already exists.
-    ///
-    /// NOTE: LOW-LEVEL: This will not attempt to maintain total issuance. It is expected that
-    /// the caller will do this.
-    fn try_mutate_account<R, E: From<DispatchError>>(
-        who: &<T as Config<I>>::AccountId,
-        f: impl FnOnce(&mut AccountData<T::Balance>, bool) -> Result<R, E>,
-    ) -> Result<R, E> {
-        Self::try_mutate_account_with_dust(who, f).map(|(result, dust_cleaner)| {
-            drop(dust_cleaner);
-            result
-        })
-    }
+	/// Mutate an account to some new value, or delete it entirely with `None`. Will enforce
+	/// `ExistentialDeposit` law, annulling the account as needed. This will do nothing if the
+	/// result of `f` is an `Err`.
+	///
+	/// NOTE: Doesn't do any preparatory work for creating a new account, so should only be used
+	/// when it is known that the account already exists.
+	///
+	/// NOTE: LOW-LEVEL: This will not attempt to maintain total issuance. It is expected that
+	/// the caller will do this.
+	fn try_mutate_account<R, E: From<DispatchError>>(
+		who: &<T as Config<I>>::AccountId,
+		f: impl FnOnce(&mut AccountData<T::Balance>, bool) -> Result<R, E>,
+	) -> Result<R, E> {
+		Self::try_mutate_account_with_dust(who, f).map(|(result, dust_cleaner)| {
+			drop(dust_cleaner);
+			result
+		})
+	}
 
-    /// Mutate an account to some new value, or delete it entirely with `None`. Will enforce
-    /// `ExistentialDeposit` law, annulling the account as needed. This will do nothing if the
-    /// result of `f` is an `Err`.
-    ///
-    /// It returns both the result from the closure, and an optional `DustCleaner` instance which
-    /// should be dropped once it is known that all nested mutates that could affect storage items
-    /// what the dust handler touches have completed.
-    ///
-    /// NOTE: Doesn't do any preparatory work for creating a new account, so should only be used
-    /// when it is known that the account already exists.
-    ///
-    /// NOTE: LOW-LEVEL: This will not attempt to maintain total issuance. It is expected that
-    /// the caller will do this.
-    fn try_mutate_account_with_dust<R, E: From<DispatchError>>(
-        who: &<T as Config<I>>::AccountId,
-        f: impl FnOnce(&mut AccountData<T::Balance>, bool) -> Result<R, E>,
-    ) -> Result<(R, DustCleaner<T, I>), E> {
-        let result = T::AccountStore::try_mutate_exists(who, |maybe_account| {
-            let is_new = maybe_account.is_none();
-            let mut account = maybe_account.take().unwrap_or_default();
-            f(&mut account, is_new).map(move |result| {
-                let maybe_endowed = if is_new { Some(account.free) } else { None };
-                let maybe_account_maybe_dust = Self::post_mutation(who, account);
-                *maybe_account = maybe_account_maybe_dust.0;
-                (maybe_endowed, maybe_account_maybe_dust.1, result)
-            })
-        });
-        result.map(|(maybe_endowed, maybe_dust, result)| {
-            if let Some(endowed) = maybe_endowed {
-                Self::deposit_event(Event::Endowed {
-                    account: who.clone(),
-                    free_balance: endowed,
-                });
-            }
-            let dust_cleaner = DustCleaner(maybe_dust.map(|dust| (who.clone(), dust)));
-            (result, dust_cleaner)
-        })
-    }
+	/// Mutate an account to some new value, or delete it entirely with `None`. Will enforce
+	/// `ExistentialDeposit` law, annulling the account as needed. This will do nothing if the
+	/// result of `f` is an `Err`.
+	///
+	/// It returns both the result from the closure, and an optional `DustCleaner` instance which
+	/// should be dropped once it is known that all nested mutates that could affect storage items
+	/// what the dust handler touches have completed.
+	///
+	/// NOTE: Doesn't do any preparatory work for creating a new account, so should only be used
+	/// when it is known that the account already exists.
+	///
+	/// NOTE: LOW-LEVEL: This will not attempt to maintain total issuance. It is expected that
+	/// the caller will do this.
+	fn try_mutate_account_with_dust<R, E: From<DispatchError>>(
+		who: &<T as Config<I>>::AccountId,
+		f: impl FnOnce(&mut AccountData<T::Balance>, bool) -> Result<R, E>,
+	) -> Result<(R, DustCleaner<T, I>), E> {
+		let result = T::AccountStore::try_mutate_exists(who, |maybe_account| {
+			let is_new = maybe_account.is_none();
+			let mut account = maybe_account.take().unwrap_or_default();
+			f(&mut account, is_new).map(move |result| {
+				let maybe_endowed = if is_new { Some(account.free) } else { None };
+				let maybe_account_maybe_dust = Self::post_mutation(who, account);
+				*maybe_account = maybe_account_maybe_dust.0;
+				(maybe_endowed, maybe_account_maybe_dust.1, result)
+			})
+		});
+		result.map(|(maybe_endowed, maybe_dust, result)| {
+			if let Some(endowed) = maybe_endowed {
+				Self::deposit_event(Event::Endowed {
+					account: who.clone(),
+					free_balance: endowed,
+				});
+			}
+			let dust_cleaner = DustCleaner(maybe_dust.map(|dust| (who.clone(), dust)));
+			(result, dust_cleaner)
+		})
+	}
 
-    /// Handles any steps needed after mutating an account.
-    ///
-    /// This includes `DustRemoval` unbalancing, in the case than the `new` account's total balance
-    /// is non-zero but below ED.
-    ///
-    /// Returns two values:
-    /// - `Some` containing the the `new` account, iff the account has sufficient balance.
-    /// - `Some` containing the dust to be dropped, iff some dust should be dropped.
-    fn post_mutation(
-        _who: &<T as Config<I>>::AccountId,
-        new: AccountData<T::Balance>,
-    ) -> (
-        Option<AccountData<T::Balance>>,
-        Option<NegativeImbalance<T, I>>,
-    ) {
-        let total = new.total();
-        if total < T::ExistentialDeposit::get() {
-            if total.is_zero() {
-                (None, None)
-            } else {
-                (None, Some(NegativeImbalance::new(total)))
-            }
-        } else {
-            (Some(new), None)
-        }
-    }
+	/// Handles any steps needed after mutating an account.
+	///
+	/// This includes `DustRemoval` unbalancing, in the case than the `new` account's total balance
+	/// is non-zero but below ED.
+	///
+	/// Returns two values:
+	/// - `Some` containing the the `new` account, iff the account has sufficient balance.
+	/// - `Some` containing the dust to be dropped, iff some dust should be dropped.
+	fn post_mutation(
+		_who: &<T as Config<I>>::AccountId,
+		new: AccountData<T::Balance>,
+	) -> (
+		Option<AccountData<T::Balance>>,
+		Option<NegativeImbalance<T, I>>,
+	) {
+		let total = new.total();
+		if total < T::ExistentialDeposit::get() {
+			if total.is_zero() {
+				(None, None)
+			} else {
+				(None, Some(NegativeImbalance::new(total)))
+			}
+		} else {
+			(Some(new), None)
+		}
+	}
 
-    fn deposit_consequence(
-        _who: &<T as Config<I>>::AccountId,
-        amount: T::Balance,
-        account: &AccountData<T::Balance>,
-        mint: bool,
-    ) -> DepositConsequence {
-        if amount.is_zero() {
-            return DepositConsequence::Success;
-        }
+	fn deposit_consequence(
+		_who: &<T as Config<I>>::AccountId,
+		amount: T::Balance,
+		account: &AccountData<T::Balance>,
+		mint: bool,
+	) -> DepositConsequence {
+		if amount.is_zero() {
+			return DepositConsequence::Success;
+		}
 
-        if mint && TotalIssuance::<T, I>::get().checked_add(&amount).is_none() {
-            return DepositConsequence::Overflow;
-        }
+		if mint && TotalIssuance::<T, I>::get().checked_add(&amount).is_none() {
+			return DepositConsequence::Overflow;
+		}
 
-        let new_total_balance = match account.total().checked_add(&amount) {
-            Some(x) => x,
-            None => return DepositConsequence::Overflow,
-        };
+		let new_total_balance = match account.total().checked_add(&amount) {
+			Some(x) => x,
+			None => return DepositConsequence::Overflow,
+		};
 
-        if new_total_balance < T::ExistentialDeposit::get() {
-            return DepositConsequence::BelowMinimum;
-        }
+		if new_total_balance < T::ExistentialDeposit::get() {
+			return DepositConsequence::BelowMinimum;
+		}
 
-        // NOTE: We assume that we are a provider, so don't need to do any checks in the
-        // case of account creation.
+		// NOTE: We assume that we are a provider, so don't need to do any checks in the
+		// case of account creation.
 
-        DepositConsequence::Success
-    }
+		DepositConsequence::Success
+	}
 
-    fn withdraw_consequence(
-        _who: &<T as Config<I>>::AccountId,
-        amount: T::Balance,
-        account: &AccountData<T::Balance>,
-    ) -> WithdrawConsequence<T::Balance> {
-        if amount.is_zero() {
-            return WithdrawConsequence::Success;
-        }
+	fn withdraw_consequence(
+		_who: &<T as Config<I>>::AccountId,
+		amount: T::Balance,
+		account: &AccountData<T::Balance>,
+	) -> WithdrawConsequence<T::Balance> {
+		if amount.is_zero() {
+			return WithdrawConsequence::Success;
+		}
 
-        if TotalIssuance::<T, I>::get().checked_sub(&amount).is_none() {
-            return WithdrawConsequence::Underflow;
-        }
+		if TotalIssuance::<T, I>::get().checked_sub(&amount).is_none() {
+			return WithdrawConsequence::Underflow;
+		}
 
-        let new_total_balance = match account.total().checked_sub(&amount) {
-            Some(x) => x,
-            None => return WithdrawConsequence::NoFunds,
-        };
+		let new_total_balance = match account.total().checked_sub(&amount) {
+			Some(x) => x,
+			None => return WithdrawConsequence::NoFunds,
+		};
 
-        // Provider restriction - total account balance cannot be reduced to zero if it cannot
-        // sustain the loss of a provider reference.
-        // NOTE: This assumes that the pallet is a provider (which is true). Is this ever changes,
-        // then this will need to adapt accordingly.
-        let ed = T::ExistentialDeposit::get();
-        if new_total_balance < ed {
-            return WithdrawConsequence::WouldDie;
-        }
+		// Provider restriction - total account balance cannot be reduced to zero if it cannot
+		// sustain the loss of a provider reference.
+		// NOTE: This assumes that the pallet is a provider (which is true). Is this ever changes,
+		// then this will need to adapt accordingly.
+		let ed = T::ExistentialDeposit::get();
+		if new_total_balance < ed {
+			return WithdrawConsequence::WouldDie;
+		}
 
-        // Enough free funds to have them be reduced.
-        match account.free.checked_sub(&amount) {
-            Some(_) => WithdrawConsequence::Success,
-            None => WithdrawConsequence::NoFunds,
-        }
-    }
+		// Enough free funds to have them be reduced.
+		match account.free.checked_sub(&amount) {
+			Some(_) => WithdrawConsequence::Success,
+			None => WithdrawConsequence::NoFunds,
+		}
+	}
 }
 
 impl<T: Config<I>, I: 'static> Currency<<T as Config<I>>::AccountId> for Pallet<T, I>
 where
-    T::Balance: MaybeSerializeDeserialize + Debug,
+	T::Balance: MaybeSerializeDeserialize + Debug,
 {
-    type Balance = T::Balance;
-    type PositiveImbalance = PositiveImbalance<T, I>;
-    type NegativeImbalance = NegativeImbalance<T, I>;
+	type Balance = T::Balance;
+	type PositiveImbalance = PositiveImbalance<T, I>;
+	type NegativeImbalance = NegativeImbalance<T, I>;
 
-    fn total_balance(who: &<T as Config<I>>::AccountId) -> Self::Balance {
-        Self::account(who).total()
-    }
+	fn total_balance(who: &<T as Config<I>>::AccountId) -> Self::Balance {
+		Self::account(who).total()
+	}
 
-    fn can_slash(who: &<T as Config<I>>::AccountId, value: Self::Balance) -> bool {
-        if value.is_zero() {
-            return true;
-        }
-        Self::free_balance(who) >= value
-    }
+	fn can_slash(who: &<T as Config<I>>::AccountId, value: Self::Balance) -> bool {
+		if value.is_zero() {
+			return true;
+		}
+		Self::free_balance(who) >= value
+	}
 
-    fn total_issuance() -> Self::Balance {
-        TotalIssuance::<T, I>::get()
-    }
+	fn total_issuance() -> Self::Balance {
+		TotalIssuance::<T, I>::get()
+	}
 
-    fn active_issuance() -> Self::Balance {
-        <Self as fungible::Inspect<<T as Config<I>>::AccountId>>::active_issuance()
-    }
+	fn active_issuance() -> Self::Balance {
+		<Self as fungible::Inspect<<T as Config<I>>::AccountId>>::active_issuance()
+	}
 
-    fn deactivate(amount: Self::Balance) {
-        InactiveIssuance::<T, I>::mutate(|b| b.saturating_accrue(amount));
-    }
+	fn deactivate(amount: Self::Balance) {
+		InactiveIssuance::<T, I>::mutate(|b| b.saturating_accrue(amount));
+	}
 
-    fn reactivate(amount: Self::Balance) {
-        InactiveIssuance::<T, I>::mutate(|b| b.saturating_reduce(amount));
-    }
+	fn reactivate(amount: Self::Balance) {
+		InactiveIssuance::<T, I>::mutate(|b| b.saturating_reduce(amount));
+	}
 
-    fn minimum_balance() -> Self::Balance {
-        T::ExistentialDeposit::get()
-    }
+	fn minimum_balance() -> Self::Balance {
+		T::ExistentialDeposit::get()
+	}
 
-    fn burn(mut amount: Self::Balance) -> Self::PositiveImbalance {
-        if amount.is_zero() {
-            return PositiveImbalance::zero();
-        }
-        <TotalIssuance<T, I>>::mutate(|issued| {
-            *issued = issued.checked_sub(&amount).unwrap_or_else(|| {
-                amount = *issued;
-                Zero::zero()
-            });
-        });
-        PositiveImbalance::new(amount)
-    }
+	fn burn(mut amount: Self::Balance) -> Self::PositiveImbalance {
+		if amount.is_zero() {
+			return PositiveImbalance::zero();
+		}
+		<TotalIssuance<T, I>>::mutate(|issued| {
+			*issued = issued.checked_sub(&amount).unwrap_or_else(|| {
+				amount = *issued;
+				Zero::zero()
+			});
+		});
+		PositiveImbalance::new(amount)
+	}
 
-    fn issue(mut amount: Self::Balance) -> Self::NegativeImbalance {
-        if amount.is_zero() {
-            return NegativeImbalance::zero();
-        }
-        <TotalIssuance<T, I>>::mutate(|issued| {
-            *issued = issued.checked_add(&amount).unwrap_or_else(|| {
-                amount = Self::Balance::max_value() - *issued;
-                Self::Balance::max_value()
-            })
-        });
-        NegativeImbalance::new(amount)
-    }
+	fn issue(mut amount: Self::Balance) -> Self::NegativeImbalance {
+		if amount.is_zero() {
+			return NegativeImbalance::zero();
+		}
+		<TotalIssuance<T, I>>::mutate(|issued| {
+			*issued = issued.checked_add(&amount).unwrap_or_else(|| {
+				amount = Self::Balance::max_value() - *issued;
+				Self::Balance::max_value()
+			})
+		});
+		NegativeImbalance::new(amount)
+	}
 
-    fn free_balance(who: &<T as Config<I>>::AccountId) -> Self::Balance {
-        Self::account(who).free
-    }
+	fn free_balance(who: &<T as Config<I>>::AccountId) -> Self::Balance {
+		Self::account(who).free
+	}
 
 	// We don't have any existing withdrawal restrictions like locks and vesting balance.
-    fn ensure_can_withdraw(
-        _who: &<T as Config<I>>::AccountId,
-        _amount: T::Balance,
-        _reasons: WithdrawReasons,
-        _new_balance: T::Balance,
-    ) -> DispatchResult {
-        Ok(())
-    }
+	fn ensure_can_withdraw(
+		_who: &<T as Config<I>>::AccountId,
+		_amount: T::Balance,
+		_reasons: WithdrawReasons,
+		_new_balance: T::Balance,
+	) -> DispatchResult {
+		Ok(())
+	}
 
-    fn transfer(
-        transactor: &<T as Config<I>>::AccountId,
-        dest: &<T as Config<I>>::AccountId,
-        value: Self::Balance,
-        existence_requirement: ExistenceRequirement,
-    ) -> DispatchResult {
-        if value.is_zero() || transactor == dest {
-            return Ok(());
-        }
+	fn transfer(
+		transactor: &<T as Config<I>>::AccountId,
+		dest: &<T as Config<I>>::AccountId,
+		value: Self::Balance,
+		existence_requirement: ExistenceRequirement,
+	) -> DispatchResult {
+		if value.is_zero() || transactor == dest {
+			return Ok(());
+		}
 
-        Self::try_mutate_account_with_dust(
-            dest,
-            |to_account, _| -> Result<DustCleaner<T, I>, DispatchError> {
-                Self::try_mutate_account_with_dust(
-                    transactor,
-                    |from_account, _| -> DispatchResult {
-                        from_account.free = from_account
-                            .free
-                            .checked_sub(&value)
-                            .ok_or(Error::<T, I>::InsufficientBalance)?;
+		Self::try_mutate_account_with_dust(
+			dest,
+			|to_account, _| -> Result<DustCleaner<T, I>, DispatchError> {
+				Self::try_mutate_account_with_dust(
+					transactor,
+					|from_account, _| -> DispatchResult {
+						from_account.free = from_account
+							.free
+							.checked_sub(&value)
+							.ok_or(Error::<T, I>::InsufficientBalance)?;
 
-                        // NOTE: total stake being stored in the same type means that this could
-                        // never overflow but better to be safe than sorry.
-                        to_account.free = to_account
-                            .free
-                            .checked_add(&value)
-                            .ok_or(ArithmeticError::Overflow)?;
+						to_account.free = to_account
+							.free
+							.checked_add(&value)
+							.ok_or(ArithmeticError::Overflow)?;
 
-                        let ed = T::ExistentialDeposit::get();
-                        ensure!(to_account.total() >= ed, Error::<T, I>::ExistentialDeposit);
+						let ed = T::ExistentialDeposit::get();
+						ensure!(to_account.total() >= ed, Error::<T, I>::ExistentialDeposit);
 
-                        Self::ensure_can_withdraw(
-                            transactor,
-                            value,
-                            WithdrawReasons::TRANSFER,
-                            from_account.free,
-                        )
-                        .map_err(|_| Error::<T, I>::LiquidityRestrictions)?;
+						Self::ensure_can_withdraw(
+							transactor,
+							value,
+							WithdrawReasons::TRANSFER,
+							from_account.free,
+						)
+						.map_err(|_| Error::<T, I>::LiquidityRestrictions)?;
 
-                        // TODO: This is over-conservative. There may now be other providers, and
-                        // this pallet may not even be a provider.
-                        let allow_death = existence_requirement == ExistenceRequirement::AllowDeath;
-                        ensure!(
-                            allow_death || from_account.total() >= ed,
-                            Error::<T, I>::KeepAlive
-                        );
+						let allow_death = existence_requirement == ExistenceRequirement::AllowDeath;
+						ensure!(
+							allow_death || from_account.total() >= ed,
+							Error::<T, I>::KeepAlive
+						);
 
-                        Ok(())
-                    },
-                )
-                .map(|(_, maybe_dust_cleaner)| maybe_dust_cleaner)
-            },
-        )?;
+						Ok(())
+					},
+				)
+				.map(|(_, maybe_dust_cleaner)| maybe_dust_cleaner)
+			},
+		)?;
 
-        // Emit transfer event.
-        Self::deposit_event(Event::Transfer {
-            from: transactor.clone(),
-            to: dest.clone(),
-            amount: value,
-        });
+		// Emit transfer event.
+		Self::deposit_event(Event::Transfer {
+			from: transactor.clone(),
+			to: dest.clone(),
+			amount: value,
+		});
 
-        Ok(())
-    }
+		Ok(())
+	}
 
-    /// Slash a target account `who`, returning the negative imbalance created and any left over
-    /// amount that could not be slashed.
-    ///
-    /// Is a no-op if `value` to be slashed is zero or the account does not exist.
-    ///
-    /// NOTE: `slash()` prefers free balance, but assumes that reserve balance can be drawn
-    /// from in extreme circumstances. `can_slash()` should be used prior to `slash()` to avoid
-    /// having to draw from reserved funds, however we err on the side of punishment if things are
-    /// inconsistent or `can_slash` wasn't used appropriately.
-    fn slash(
-        who: &<T as Config<I>>::AccountId,
-        value: Self::Balance,
-    ) -> (Self::NegativeImbalance, Self::Balance) {
-        if value.is_zero() {
-            return (NegativeImbalance::zero(), Zero::zero());
-        }
-        if Self::total_balance(who).is_zero() {
-            return (NegativeImbalance::zero(), value);
-        }
+	/// Slash a target account `who`, returning the negative imbalance created and any left over
+	/// amount that could not be slashed.
+	///
+	/// Is a no-op if `value` to be slashed is zero or the account does not exist.
+	///
+	/// NOTE: `slash()` prefers free balance, but assumes that reserve balance can be drawn
+	/// from in extreme circumstances. `can_slash()` should be used prior to `slash()` to avoid
+	/// having to draw from reserved funds, however we err on the side of punishment if things are
+	/// inconsistent or `can_slash` wasn't used appropriately.
+	fn slash(
+		who: &<T as Config<I>>::AccountId,
+		value: Self::Balance,
+	) -> (Self::NegativeImbalance, Self::Balance) {
+		if value.is_zero() {
+			return (NegativeImbalance::zero(), Zero::zero());
+		}
+		if Self::total_balance(who).is_zero() {
+			return (NegativeImbalance::zero(), value);
+		}
 
-        for attempt in 0..2 {
-            match Self::try_mutate_account(
+		for attempt in 0..2 {
+			match Self::try_mutate_account(
 				who,
 				|account,
 				 _is_new|
@@ -530,10 +529,7 @@ where
 						0 => value,
 						// If acting as a critical provider (i.e. first attempt failed), then slash
 						// as much as possible while leaving at least at ED.
-						_ => value.min(
-							account.free
-								.saturating_sub(T::ExistentialDeposit::get()),
-						),
+						_ => value.min(account.free.saturating_sub(T::ExistentialDeposit::get())),
 					};
 
 					let free_slash = cmp::min(account.free, best_value);
@@ -550,133 +546,133 @@ where
 						who: who.clone(),
 						amount: value.saturating_sub(not_slashed),
 					});
-					return (imbalance, not_slashed)
-				},
+					return (imbalance, not_slashed);
+				}
 				Err(_) => (),
 			}
-        }
+		}
 
-        // Should never get here. But we'll be defensive anyway.
-        (Self::NegativeImbalance::zero(), value)
-    }
+		// Should never get here. But we'll be defensive anyway.
+		(Self::NegativeImbalance::zero(), value)
+	}
 
-    /// Deposit some `value` into the free balance of an existing target account `who`.
-    ///
-    /// Is a no-op if the `value` to be deposited is zero.
-    fn deposit_into_existing(
-        who: &<T as Config<I>>::AccountId,
-        value: Self::Balance,
-    ) -> Result<Self::PositiveImbalance, DispatchError> {
-        if value.is_zero() {
-            return Ok(PositiveImbalance::zero());
-        }
+	/// Deposit some `value` into the free balance of an existing target account `who`.
+	///
+	/// Is a no-op if the `value` to be deposited is zero.
+	fn deposit_into_existing(
+		who: &<T as Config<I>>::AccountId,
+		value: Self::Balance,
+	) -> Result<Self::PositiveImbalance, DispatchError> {
+		if value.is_zero() {
+			return Ok(PositiveImbalance::zero());
+		}
 
-        Self::try_mutate_account(
-            who,
-            |account, is_new| -> Result<Self::PositiveImbalance, DispatchError> {
-                ensure!(!is_new, Error::<T, I>::DeadAccount);
-                account.free = account
-                    .free
-                    .checked_add(&value)
-                    .ok_or(ArithmeticError::Overflow)?;
-                Self::deposit_event(Event::Deposit {
-                    who: who.clone(),
-                    amount: value,
-                });
-                Ok(PositiveImbalance::new(value))
-            },
-        )
-    }
+		Self::try_mutate_account(
+			who,
+			|account, is_new| -> Result<Self::PositiveImbalance, DispatchError> {
+				ensure!(!is_new, Error::<T, I>::DeadAccount);
+				account.free = account
+					.free
+					.checked_add(&value)
+					.ok_or(ArithmeticError::Overflow)?;
+				Self::deposit_event(Event::Deposit {
+					who: who.clone(),
+					amount: value,
+				});
+				Ok(PositiveImbalance::new(value))
+			},
+		)
+	}
 
-    /// Deposit some `value` into the free balance of `who`, possibly creating a new account.
-    ///
-    /// This function is a no-op if:
-    /// - the `value` to be deposited is zero; or
-    /// - the `value` to be deposited is less than the required ED and the account does not yet
-    ///   exist; or
-    /// - the deposit would necessitate the account to exist and there are no provider references;
-    ///   or
-    /// - `value` is so large it would cause the balance of `who` to overflow.
-    fn deposit_creating(
-        who: &<T as Config<I>>::AccountId,
-        value: Self::Balance,
-    ) -> Self::PositiveImbalance {
-        if value.is_zero() {
-            return Self::PositiveImbalance::zero();
-        }
+	/// Deposit some `value` into the free balance of `who`, possibly creating a new account.
+	///
+	/// This function is a no-op if:
+	/// - the `value` to be deposited is zero; or
+	/// - the `value` to be deposited is less than the required ED and the account does not yet
+	///   exist; or
+	/// - the deposit would necessitate the account to exist and there are no provider references;
+	///   or
+	/// - `value` is so large it would cause the balance of `who` to overflow.
+	fn deposit_creating(
+		who: &<T as Config<I>>::AccountId,
+		value: Self::Balance,
+	) -> Self::PositiveImbalance {
+		if value.is_zero() {
+			return Self::PositiveImbalance::zero();
+		}
 
-        Self::try_mutate_account(
-            who,
-            |account, is_new| -> Result<Self::PositiveImbalance, DispatchError> {
-                let ed = T::ExistentialDeposit::get();
-                ensure!(value >= ed || !is_new, Error::<T, I>::ExistentialDeposit);
+		Self::try_mutate_account(
+			who,
+			|account, is_new| -> Result<Self::PositiveImbalance, DispatchError> {
+				let ed = T::ExistentialDeposit::get();
+				ensure!(value >= ed || !is_new, Error::<T, I>::ExistentialDeposit);
 
-                // defensive only: overflow should never happen, however in case it does, then this
-                // operation is a no-op.
-                account.free = match account.free.checked_add(&value) {
-                    Some(x) => x,
-                    None => return Ok(Self::PositiveImbalance::zero()),
-                };
+				// defensive only: overflow should never happen, however in case it does, then this
+				// operation is a no-op.
+				account.free = match account.free.checked_add(&value) {
+					Some(x) => x,
+					None => return Ok(Self::PositiveImbalance::zero()),
+				};
 
-                Self::deposit_event(Event::Deposit {
-                    who: who.clone(),
-                    amount: value,
-                });
-                Ok(PositiveImbalance::new(value))
-            },
-        )
-        .unwrap_or_else(|_| Self::PositiveImbalance::zero())
-    }
+				Self::deposit_event(Event::Deposit {
+					who: who.clone(),
+					amount: value,
+				});
+				Ok(PositiveImbalance::new(value))
+			},
+		)
+		.unwrap_or_else(|_| Self::PositiveImbalance::zero())
+	}
 
-    /// Withdraw some free balance from an account, respecting existence requirements.
-    ///
-    /// Is a no-op if value to be withdrawn is zero.
-    fn withdraw(
-        who: &<T as Config<I>>::AccountId,
-        value: Self::Balance,
-        reasons: WithdrawReasons,
-        liveness: ExistenceRequirement,
-    ) -> result::Result<Self::NegativeImbalance, DispatchError> {
-        if value.is_zero() {
-            return Ok(NegativeImbalance::zero());
-        }
+	/// Withdraw some free balance from an account, respecting existence requirements.
+	///
+	/// Is a no-op if value to be withdrawn is zero.
+	fn withdraw(
+		who: &<T as Config<I>>::AccountId,
+		value: Self::Balance,
+		reasons: WithdrawReasons,
+		liveness: ExistenceRequirement,
+	) -> result::Result<Self::NegativeImbalance, DispatchError> {
+		if value.is_zero() {
+			return Ok(NegativeImbalance::zero());
+		}
 
-        Self::try_mutate_account(
-            who,
-            |account, _| -> Result<Self::NegativeImbalance, DispatchError> {
-                let new_free_account = account
-                    .free
-                    .checked_sub(&value)
-                    .ok_or(Error::<T, I>::InsufficientBalance)?;
+		Self::try_mutate_account(
+			who,
+			|account, _| -> Result<Self::NegativeImbalance, DispatchError> {
+				let new_free_account = account
+					.free
+					.checked_sub(&value)
+					.ok_or(Error::<T, I>::InsufficientBalance)?;
 
-                // bail if we need to keep the account alive and this would kill it.
-                let ed = T::ExistentialDeposit::get();
-                let would_be_dead = new_free_account < ed;
-                let would_kill = would_be_dead && account.free >= ed;
-                ensure!(
-                    liveness == AllowDeath || !would_kill,
-                    Error::<T, I>::KeepAlive
-                );
+				// bail if we need to keep the account alive and this would kill it.
+				let ed = T::ExistentialDeposit::get();
+				let would_be_dead = new_free_account < ed;
+				let would_kill = would_be_dead && account.free >= ed;
+				ensure!(
+					liveness == AllowDeath || !would_kill,
+					Error::<T, I>::KeepAlive
+				);
 
-                Self::ensure_can_withdraw(who, value, reasons, new_free_account)?;
+				Self::ensure_can_withdraw(who, value, reasons, new_free_account)?;
 
-                account.free = new_free_account;
+				account.free = new_free_account;
 
-                Self::deposit_event(Event::Withdraw {
-                    who: who.clone(),
-                    amount: value,
-                });
-                Ok(NegativeImbalance::new(value))
-            },
-        )
-    }
+				Self::deposit_event(Event::Withdraw {
+					who: who.clone(),
+					amount: value,
+				});
+				Ok(NegativeImbalance::new(value))
+			},
+		)
+	}
 
-    /// Force the new free balance of a target account `who` to some new value `balance`.
-    fn make_free_balance_be(
-        who: &<T as Config<I>>::AccountId,
-        value: Self::Balance,
-    ) -> SignedImbalance<Self::Balance, Self::PositiveImbalance> {
-        Self::try_mutate_account(
+	/// Force the new free balance of a target account `who` to some new value `balance`.
+	fn make_free_balance_be(
+		who: &<T as Config<I>>::AccountId,
+		value: Self::Balance,
+	) -> SignedImbalance<Self::Balance, Self::PositiveImbalance> {
+		Self::try_mutate_account(
 			who,
 			|account,
 			 is_new|
@@ -706,55 +702,55 @@ where
 			},
 		)
 		.unwrap_or_else(|_| SignedImbalance::Positive(Self::PositiveImbalance::zero()))
-    }
+	}
 }
 
 impl<T: Config<I>, I: 'static> fungible::Inspect<<T as Config<I>>::AccountId> for Pallet<T, I> {
-    type Balance = T::Balance;
+	type Balance = T::Balance;
 
-    fn total_issuance() -> Self::Balance {
-        TotalIssuance::<T, I>::get()
-    }
+	fn total_issuance() -> Self::Balance {
+		TotalIssuance::<T, I>::get()
+	}
 
-    fn active_issuance() -> Self::Balance {
-        TotalIssuance::<T, I>::get().saturating_sub(InactiveIssuance::<T, I>::get())
-    }
+	fn active_issuance() -> Self::Balance {
+		TotalIssuance::<T, I>::get().saturating_sub(InactiveIssuance::<T, I>::get())
+	}
 
-    fn minimum_balance() -> Self::Balance {
-        T::ExistentialDeposit::get()
-    }
+	fn minimum_balance() -> Self::Balance {
+		T::ExistentialDeposit::get()
+	}
 
-    fn balance(who: &<T as Config<I>>::AccountId) -> Self::Balance {
-        Self::account(who).total()
-    }
+	fn balance(who: &<T as Config<I>>::AccountId) -> Self::Balance {
+		Self::account(who).total()
+	}
 
-    fn reducible_balance(who: &<T as Config<I>>::AccountId, keep_alive: bool) -> Self::Balance {
-        let a = Self::account(who);
-        // Liquid balance is what is neither reserved nor locked/frozen.
-        let liquid = a.free;
-        if !keep_alive {
-            liquid
-        } else {
-            // `must_remain_to_exist` is the part of liquid balance which must remain to keep total
-            // over ED.
-            let must_remain_to_exist =
-                T::ExistentialDeposit::get().saturating_sub(a.total() - liquid);
-            liquid.saturating_sub(must_remain_to_exist)
-        }
-    }
+	fn reducible_balance(who: &<T as Config<I>>::AccountId, keep_alive: bool) -> Self::Balance {
+		let a = Self::account(who);
+		// Liquid balance is what is neither reserved nor locked/frozen.
+		let liquid = a.free;
+		if !keep_alive {
+			liquid
+		} else {
+			// `must_remain_to_exist` is the part of liquid balance which must remain to keep total
+			// over ED.
+			let must_remain_to_exist =
+				T::ExistentialDeposit::get().saturating_sub(a.total() - liquid);
+			liquid.saturating_sub(must_remain_to_exist)
+		}
+	}
 
-    fn can_deposit(
-        who: &<T as Config<I>>::AccountId,
-        amount: Self::Balance,
-        mint: bool,
-    ) -> DepositConsequence {
-        Self::deposit_consequence(who, amount, &Self::account(who), mint)
-    }
+	fn can_deposit(
+		who: &<T as Config<I>>::AccountId,
+		amount: Self::Balance,
+		mint: bool,
+	) -> DepositConsequence {
+		Self::deposit_consequence(who, amount, &Self::account(who), mint)
+	}
 
-    fn can_withdraw(
-        who: &<T as Config<I>>::AccountId,
-        amount: Self::Balance,
-    ) -> WithdrawConsequence<Self::Balance> {
-        Self::withdraw_consequence(who, amount, &Self::account(who))
-    }
+	fn can_withdraw(
+		who: &<T as Config<I>>::AccountId,
+		amount: Self::Balance,
+	) -> WithdrawConsequence<Self::Balance> {
+		Self::withdraw_consequence(who, amount, &Self::account(who))
+	}
 }

--- a/frame/evm-balances/src/lib.rs
+++ b/frame/evm-balances/src/lib.rs
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+// This file is part of Frontier.
+//
+// Copyright (c) 2020-2022 Parity Technologies (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! # EVM Balances Pallet.
+
+// Ensure we're `no_std` when compiling for Wasm.
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use sp_runtime::{traits::One, RuntimeDebug, DispatchResult};
+use scale_codec::{Encode, Decode, MaxEncodedLen, FullCodec};
+use scale_info::TypeInfo;
+
+#[cfg(test)]
+mod mock;
+#[cfg(test)]
+mod tests;
+
+pub use pallet::*;
+
+#[frame_support::pallet]
+pub mod pallet {
+	use super::*;
+	use frame_support::pallet_prelude::*;
+	use sp_runtime::traits::{MaybeDisplay, AtLeast32Bit};
+	use sp_std::fmt::Debug;
+
+	#[pallet::pallet]
+	#[pallet::generate_store(pub(super) trait Store)]
+	#[pallet::without_storage_info]
+	pub struct Pallet<T>(PhantomData<T>);
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {
+		/// The overarching event type.
+		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+
+		/// The user account identifier type.
+		type AccountId: Parameter
+			+ Member
+			+ MaybeSerializeDeserialize
+			+ Debug
+			+ MaybeDisplay
+			+ Ord
+			+ MaxEncodedLen;
+
+		/// Account index (aka nonce) type. This stores the number of previous transactions
+		/// associated with a sender account.
+		type Index: Parameter
+			+ Member
+			+ MaybeSerializeDeserialize
+			+ Debug
+			+ Default
+			+ MaybeDisplay
+			+ AtLeast32Bit
+			+ Copy
+			+ MaxEncodedLen;
+	}
+
+	#[pallet::event]
+	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	pub enum Event<T: Config> {}
+
+    #[pallet::error]
+    pub enum Error<T> {}
+}

--- a/frame/evm-balances/src/mock.rs
+++ b/frame/evm-balances/src/mock.rs
@@ -141,31 +141,8 @@ parameter_types! {
 	pub WeightPerGas: Weight = Weight::from_ref_time(20_000);
 }
 
-pub struct EvmAccountProvider;
-
-impl pallet_evm::AccountProvider for EvmAccountProvider {
-	type AccountId = H160;
-	type Index = u64;
-
-	fn create_account(who: &Self::AccountId) {
-		let _ = EvmSystem::create_account(who);
-	}
-
-	fn remove_account(who: &Self::AccountId) {
-		let _ = EvmSystem::remove_account(who);
-	}
-
-	fn account_nonce(who: &Self::AccountId) -> Self::Index {
-		EvmSystem::account_nonce(who)
-	}
-
-	fn inc_account_nonce(who: &Self::AccountId) {
-		EvmSystem::inc_account_nonce(who);
-	}
-}
-
 impl pallet_evm::Config for Test {
-	type AccountProvider = EvmAccountProvider;
+	type AccountProvider = EvmSystem;
 	type FeeCalculator = FixedGasPrice;
 	type GasWeightMapping = FixedGasWeightMapping<Self>;
 	type WeightPerGas = WeightPerGas;

--- a/frame/evm-balances/src/mock.rs
+++ b/frame/evm-balances/src/mock.rs
@@ -37,6 +37,14 @@ use crate::{self as pallet_evm_balances, *};
 
 pub(crate) const INIT_BALANCE: u64 = 10_000_000;
 
+pub(crate) fn alice() -> H160 {
+	H160::from_str("1000000000000000000000000000000000000000").unwrap()
+}
+
+pub(crate) fn bob() -> H160 {
+	H160::from_str("2000000000000000000000000000000000000000").unwrap()
+}
+
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
@@ -193,14 +201,8 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 					nonce: Default::default(),
 					storage: Default::default(),
 				};
-				map.insert(
-					H160::from_str("1000000000000000000000000000000000000000").unwrap(),
-					init_genesis_account.clone(),
-				);
-				map.insert(
-					H160::from_str("2000000000000000000000000000000000000000").unwrap(),
-					init_genesis_account,
-				);
+				map.insert(alice(), init_genesis_account.clone());
+				map.insert(bob(), init_genesis_account);
 				map
 			},
 		},

--- a/frame/evm-balances/src/mock.rs
+++ b/frame/evm-balances/src/mock.rs
@@ -101,7 +101,7 @@ impl pallet_evm_balances::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type AccountId = H160;
 	type Balance = u64;
-	type ExistentialDeposit = ConstU64<500>;
+	type ExistentialDeposit = ConstU64<1>;
 	type AccountStore = EvmSystem;
 	type DustRemoval = ();
 }

--- a/frame/evm-balances/src/mock.rs
+++ b/frame/evm-balances/src/mock.rs
@@ -35,7 +35,7 @@ use sp_std::{boxed::Box, prelude::*, str::FromStr};
 
 use crate::{self as pallet_evm_balances, *};
 
-pub(crate) const INIT_BALANCE: u64 = 10_000_000;
+pub(crate) const INIT_BALANCE: u64 = 10_000_000_000_000_000;
 
 pub(crate) fn alice() -> H160 {
 	H160::from_str("1000000000000000000000000000000000000000").unwrap()

--- a/frame/evm-balances/src/mock.rs
+++ b/frame/evm-balances/src/mock.rs
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// This file is part of Frontier.
+//
+// Copyright (c) 2020-2022 Parity Technologies (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Test mock for unit tests.

--- a/frame/evm-balances/src/tests.rs
+++ b/frame/evm-balances/src/tests.rs
@@ -1,0 +1,1 @@
+//! Unit tests.

--- a/frame/evm-balances/src/tests.rs
+++ b/frame/evm-balances/src/tests.rs
@@ -88,10 +88,32 @@ fn deposit_into_existing_works() {
 			who: alice(),
 			amount: deposited_amount,
 		}));
+	});
+}
+
+#[test]
+fn slashing_balance_works() {
+	new_test_ext().execute_with_ext(|_| {
+		// Check test preconditions.
+		assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
+
+		let slashed_amount = 1000;
+
+		// Set block number to enable events.
+		System::set_block_number(1);
+
+		// Invoke the function under test.
+		assert!(EvmBalances::slash(&alice(), 1000).1.is_zero());
+
+		// Assert state changes.
 		assert_eq!(
 			EvmBalances::total_balance(&alice()),
-			INIT_BALANCE + deposited_amount
+			INIT_BALANCE - slashed_amount
 		);
+		System::assert_has_event(RuntimeEvent::EvmBalances(crate::Event::Slashed {
+			who: alice(),
+			amount: slashed_amount,
+		}));
 	});
 }
 

--- a/frame/evm-balances/src/tests.rs
+++ b/frame/evm-balances/src/tests.rs
@@ -27,6 +27,55 @@ fn basic_setup_works() {
 }
 
 #[test]
+fn currency_total_balance_works() {
+	new_test_ext().execute_with_ext(|_| {
+		// Check the total balance value.
+		assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
+	});
+}
+
+#[test]
+fn currency_can_slash_works() {
+	new_test_ext().execute_with_ext(|_| {
+		// Check slashing.
+		assert!(EvmBalances::can_slash(&alice(), 100));
+	});
+}
+
+#[test]
+fn currency_total_issuance_works() {
+	new_test_ext().execute_with_ext(|_| {
+		// Check the total issuance value.
+		assert_eq!(EvmBalances::total_issuance(), 2 * INIT_BALANCE);
+	});
+}
+
+#[test]
+fn currency_active_issuance_works() {
+	new_test_ext().execute_with_ext(|_| {
+		// Check the active issuance value.
+		assert_eq!(EvmBalances::active_issuance(), 2 * INIT_BALANCE);
+	});
+}
+
+#[test]
+fn currency_deactivate_reactivate_works() {
+	new_test_ext().execute_with_ext(|_| {
+		// Check test preconditions.
+		assert_eq!(<InactiveIssuance<Test>>::get(), 0);
+
+		// Deactivate some balance.
+		EvmBalances::deactivate(100);
+		// Assert state changes.
+		assert_eq!(<InactiveIssuance<Test>>::get(), 100);
+		// Reactivate some balance.
+		EvmBalances::reactivate(40);
+		// Assert state changes.
+		assert_eq!(<InactiveIssuance<Test>>::get(), 60);
+	});
+}
+
+#[test]
 fn transfer_works() {
 	new_test_ext().execute_with_ext(|_| {
 		// Check test preconditions.

--- a/frame/evm-balances/src/tests.rs
+++ b/frame/evm-balances/src/tests.rs
@@ -204,6 +204,7 @@ fn currency_deposit_creating_works() {
 		// Prepare test preconditions.
 		let charlie = H160::from_str("1000000000000000000000000000000000000003").unwrap();
 		let deposited_amount = 10;
+		assert!(!EvmSystem::account_exists(&charlie));
 
 		// Set block number to enable events.
 		System::set_block_number(1);
@@ -217,6 +218,7 @@ fn currency_deposit_creating_works() {
 			who: charlie,
 			amount: deposited_amount,
 		}));
+		assert!(EvmSystem::account_exists(&charlie));
 	});
 }
 

--- a/frame/evm-balances/src/tests.rs
+++ b/frame/evm-balances/src/tests.rs
@@ -144,7 +144,7 @@ fn currency_transfer_works() {
 }
 
 #[test]
-fn currency_slashing_balance_works() {
+fn currency_slash_works() {
 	new_test_ext().execute_with_ext(|_| {
 		// Check test preconditions.
 		assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);

--- a/frame/evm-balances/src/tests.rs
+++ b/frame/evm-balances/src/tests.rs
@@ -76,6 +76,38 @@ fn currency_deactivate_reactivate_works() {
 }
 
 #[test]
+fn currency_burn_works() {
+	new_test_ext().execute_with_ext(|_| {
+		// Check test preconditions.
+		assert_eq!(EvmBalances::total_issuance(), 2 * INIT_BALANCE);
+
+		// Burn some balance.
+		let imbalance = EvmBalances::burn(100);
+
+		// Assert state changes.
+		assert_eq!(EvmBalances::total_issuance(), 2 * INIT_BALANCE - 100);
+		drop(imbalance);
+		assert_eq!(EvmBalances::total_issuance(), 2 * INIT_BALANCE);
+	});
+}
+
+#[test]
+fn currency_issue_works() {
+	new_test_ext().execute_with_ext(|_| {
+		// Check test preconditions.
+		assert_eq!(EvmBalances::total_issuance(), 2 * INIT_BALANCE);
+
+		// Issue some balance.
+		let imbalance = EvmBalances::issue(100);
+
+		// Assert state changes.
+		assert_eq!(EvmBalances::total_issuance(), 2 * INIT_BALANCE + 100);
+		drop(imbalance);
+		assert_eq!(EvmBalances::total_issuance(), 2 * INIT_BALANCE);
+	});
+}
+
+#[test]
 fn transfer_works() {
 	new_test_ext().execute_with_ext(|_| {
 		// Check test preconditions.

--- a/frame/evm-balances/src/tests.rs
+++ b/frame/evm-balances/src/tests.rs
@@ -173,3 +173,27 @@ fn call_should_fail_with_priority_greater_than_max_fee() {
 		assert_eq!(result.unwrap_err().weight, Weight::from_ref_time(7));
 	});
 }
+
+#[test]
+fn call_should_succeed_with_priority_equal_to_max_fee() {
+	new_test_ext().execute_with(|| {
+		let tip: u128 = 1_000_000_000;
+		// Mimics the input for pre-eip-1559 transaction types where `gas_price`
+		// is used for both `max_fee_per_gas` and `max_priority_fee_per_gas`.
+		let result = <Test as pallet_evm::Config>::Runner::call(
+			alice(),
+			bob(),
+			Vec::new(),
+			U256::from(1),
+			1000000,
+			Some(U256::from(1_000_000_000)),
+			Some(U256::from(tip)),
+			None,
+			Vec::new(),
+			true,
+			true,
+			<Test as pallet_evm::Config>::config(),
+		);
+		assert!(result.is_ok());
+	});
+}

--- a/frame/evm-balances/src/tests.rs
+++ b/frame/evm-balances/src/tests.rs
@@ -252,7 +252,7 @@ fn currency_withdraw_works() {
 }
 
 #[test]
-fn currency_make_free_balance_be() {
+fn currency_make_free_balance_be_works() {
 	new_test_ext().execute_with(|| {
 		// Prepare test preconditions.
 		let charlie = H160::from_str("1000000000000000000000000000000000000003").unwrap();

--- a/frame/evm-balances/src/tests.rs
+++ b/frame/evm-balances/src/tests.rs
@@ -27,6 +27,26 @@ fn basic_setup_works() {
 }
 
 #[test]
+fn account_should_be_reaped() {
+	new_test_ext().execute_with_ext(|_| {
+		// Check test preconditions.
+		assert!(EvmSystem::account_exists(&bob()));
+
+		// Invoke the function under test.
+		assert_ok!(<EvmBalances as Currency<_>>::transfer(
+			&bob(),
+			&alice(),
+			INIT_BALANCE,
+			AllowDeath
+		));
+
+		// Assert state changes.
+		assert_eq!(EvmBalances::free_balance(&bob()), 0);
+		assert!(!EvmSystem::account_exists(&bob()));
+	});
+}
+
+#[test]
 fn fee_deduction() {
 	new_test_ext().execute_with(|| {
 		let charlie = H160::from_str("1000000000000000000000000000000000000003").unwrap();

--- a/frame/evm-balances/src/tests.rs
+++ b/frame/evm-balances/src/tests.rs
@@ -27,7 +27,7 @@ fn basic_setup_works() {
 }
 
 #[test]
-fn balance_transfer_works() {
+fn transfer_works() {
 	new_test_ext().execute_with_ext(|_| {
 		// Check test preconditions.
 		assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);

--- a/frame/evm-balances/src/tests.rs
+++ b/frame/evm-balances/src/tests.rs
@@ -1,6 +1,9 @@
 //! Unit tests.
 
+use frame_support::{assert_noop, assert_ok};
+use pallet_evm::{FeeCalculator, Runner};
 use sp_core::{H160, U256};
+use sp_runtime::traits::UniqueSaturatedInto;
 use sp_std::str::FromStr;
 
 use crate::{mock::*, *};
@@ -50,5 +53,39 @@ fn fee_deduction() {
 		// Refund fees as 5 units
 		<<Test as pallet_evm::Config>::OnChargeTransaction as pallet_evm::OnChargeEVMTransaction<Test>>::correct_and_deposit_fee(&charlie, U256::from(5), U256::from(5), imbalance);
 		assert_eq!(EvmBalances::free_balance(&charlie), 95);
+	});
+}
+
+#[test]
+fn issuance_after_tip() {
+	new_test_ext().execute_with(|| {
+		let before_tip = <Test as pallet_evm::Config>::Currency::total_issuance();
+
+		// Set block number to enable events.
+		System::set_block_number(1);
+
+		assert_ok!(<Test as pallet_evm::Config>::Runner::call(
+			alice(),
+			bob(),
+			Vec::new(),
+			U256::from(1),
+			1000000,
+			Some(U256::from(2_000_000_000)),
+			None,
+			None,
+			Vec::new(),
+			true,
+			true,
+			<Test as pallet_evm::Config>::config(),
+		));
+
+		// Only base fee is burned
+		let base_fee: u64 = <Test as pallet_evm::Config>::FeeCalculator::min_gas_price()
+			.0
+			.unique_saturated_into();
+
+		let after_tip = <Test as pallet_evm::Config>::Currency::total_issuance();
+
+		assert_eq!(after_tip, (before_tip - (base_fee * 21_000)));
 	});
 }

--- a/frame/evm-balances/src/tests.rs
+++ b/frame/evm-balances/src/tests.rs
@@ -1,6 +1,6 @@
 //! Unit tests.
 
-use frame_support::{assert_noop, assert_ok};
+use frame_support::assert_ok;
 use pallet_evm::{FeeCalculator, Runner};
 use sp_core::{H160, U256};
 use sp_runtime::traits::UniqueSaturatedInto;

--- a/frame/evm-balances/src/tests.rs
+++ b/frame/evm-balances/src/tests.rs
@@ -219,6 +219,9 @@ fn currency_deposit_creating_works() {
 			amount: deposited_amount,
 		}));
 		assert!(EvmSystem::account_exists(&charlie));
+		System::assert_has_event(RuntimeEvent::EvmSystem(
+			pallet_evm_system::Event::NewAccount { account: charlie },
+		));
 	});
 }
 
@@ -277,6 +280,9 @@ fn evm_system_account_should_be_reaped() {
 		// Check test preconditions.
 		assert!(EvmSystem::account_exists(&bob()));
 
+		// Set block number to enable events.
+		System::set_block_number(1);
+
 		// Invoke the function under test.
 		assert_ok!(EvmBalances::transfer(
 			&bob(),
@@ -288,6 +294,9 @@ fn evm_system_account_should_be_reaped() {
 		// Assert state changes.
 		assert_eq!(EvmBalances::free_balance(&bob()), 0);
 		assert!(!EvmSystem::account_exists(&bob()));
+		System::assert_has_event(RuntimeEvent::EvmSystem(
+			pallet_evm_system::Event::KilledAccount { account: bob() },
+		));
 	});
 }
 

--- a/frame/evm-balances/src/tests.rs
+++ b/frame/evm-balances/src/tests.rs
@@ -1,5 +1,8 @@
 //! Unit tests.
 
+use sp_core::{H160, U256};
+use sp_std::str::FromStr;
+
 use crate::{mock::*, *};
 
 #[test]
@@ -23,5 +26,29 @@ fn basic_setup_works() {
 
 		// Check the total balance value.
 		assert_eq!(EvmBalances::total_issuance(), 2 * INIT_BALANCE);
+	});
+}
+
+#[test]
+fn fee_deduction() {
+	new_test_ext().execute_with(|| {
+		let charlie = H160::from_str("1000000000000000000000000000000000000003").unwrap();
+
+		// Seed account
+		let _ = <Test as pallet_evm::Config>::Currency::deposit_creating(&charlie, 100);
+		assert_eq!(EvmBalances::free_balance(&charlie), 100);
+
+		// Deduct fees as 10 units
+		let imbalance =
+			<<Test as pallet_evm::Config>::OnChargeTransaction as pallet_evm::OnChargeEVMTransaction<Test>>::withdraw_fee(
+				&charlie,
+				U256::from(10),
+			)
+			.unwrap();
+		assert_eq!(EvmBalances::free_balance(&charlie), 90);
+
+		// Refund fees as 5 units
+		<<Test as pallet_evm::Config>::OnChargeTransaction as pallet_evm::OnChargeEVMTransaction<Test>>::correct_and_deposit_fee(&charlie, U256::from(5), U256::from(5), imbalance);
+		assert_eq!(EvmBalances::free_balance(&charlie), 95);
 	});
 }

--- a/frame/evm-balances/src/tests.rs
+++ b/frame/evm-balances/src/tests.rs
@@ -108,7 +108,7 @@ fn currency_issue_works() {
 }
 
 #[test]
-fn transfer_works() {
+fn currency_transfer_works() {
 	new_test_ext().execute_with_ext(|_| {
 		// Check test preconditions.
 		assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
@@ -144,7 +144,7 @@ fn transfer_works() {
 }
 
 #[test]
-fn slashing_balance_works() {
+fn currency_slashing_balance_works() {
 	new_test_ext().execute_with_ext(|_| {
 		// Check test preconditions.
 		assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
@@ -170,7 +170,7 @@ fn slashing_balance_works() {
 }
 
 #[test]
-fn deposit_into_existing_works() {
+fn currency_deposit_into_existing_works() {
 	new_test_ext().execute_with_ext(|_| {
 		// Check test preconditions.
 		assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
@@ -199,7 +199,7 @@ fn deposit_into_existing_works() {
 }
 
 #[test]
-fn deposit_creating_works() {
+fn currency_deposit_creating_works() {
 	new_test_ext().execute_with_ext(|_| {
 		// Prepare test preconditions.
 		let charlie = H160::from_str("1000000000000000000000000000000000000003").unwrap();
@@ -221,7 +221,7 @@ fn deposit_creating_works() {
 }
 
 #[test]
-fn withdraw_balance_works() {
+fn currency_withdraw_works() {
 	new_test_ext().execute_with_ext(|_| {
 		// Check test preconditions.
 		assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
@@ -252,6 +252,24 @@ fn withdraw_balance_works() {
 }
 
 #[test]
+fn currency_make_free_balance_be() {
+	new_test_ext().execute_with(|| {
+		// Prepare test preconditions.
+		let charlie = H160::from_str("1000000000000000000000000000000000000003").unwrap();
+		let made_free_balance = 100;
+
+		// Check test preconditions.
+		assert_eq!(EvmBalances::total_balance(&charlie), 0);
+
+		// Invoke the function under test.
+		let _ = EvmBalances::make_free_balance_be(&charlie, made_free_balance);
+
+		// Assert state changes.
+		assert_eq!(EvmBalances::total_balance(&charlie), made_free_balance);
+	});
+}
+
+#[test]
 fn account_should_be_reaped() {
 	new_test_ext().execute_with_ext(|_| {
 		// Check test preconditions.
@@ -270,6 +288,7 @@ fn account_should_be_reaped() {
 		assert!(!EvmSystem::account_exists(&bob()));
 	});
 }
+
 #[test]
 fn transferring_too_high_value_should_not_panic() {
 	new_test_ext().execute_with(|| {

--- a/frame/evm-balances/src/tests.rs
+++ b/frame/evm-balances/src/tests.rs
@@ -1,1 +1,27 @@
 //! Unit tests.
+
+use crate::{mock::*, *};
+
+#[test]
+fn basic_setup_works() {
+	new_test_ext().execute_with_ext(|_| {
+		// Check the accounts.
+		assert_eq!(
+			<EvmSystem>::full_account(&alice()),
+			pallet_evm_system::AccountInfo {
+				nonce: 0,
+				data: account_data::AccountData { free: INIT_BALANCE }
+			}
+		);
+		assert_eq!(
+			<EvmSystem>::full_account(&bob()),
+			pallet_evm_system::AccountInfo {
+				nonce: 0,
+				data: account_data::AccountData { free: INIT_BALANCE }
+			}
+		);
+
+		// Check the total balance value.
+		assert_eq!(EvmBalances::total_issuance(), 2 * INIT_BALANCE);
+	});
+}

--- a/frame/evm-balances/src/tests.rs
+++ b/frame/evm-balances/src/tests.rs
@@ -55,9 +55,6 @@ fn issuance_after_tip() {
 	new_test_ext().execute_with(|| {
 		let before_tip = <Test as pallet_evm::Config>::Currency::total_issuance();
 
-		// Set block number to enable events.
-		System::set_block_number(1);
-
 		assert_ok!(<Test as pallet_evm::Config>::Runner::call(
 			alice(),
 			bob(),

--- a/frame/evm-balances/src/tests.rs
+++ b/frame/evm-balances/src/tests.rs
@@ -270,7 +270,7 @@ fn currency_make_free_balance_be() {
 }
 
 #[test]
-fn account_should_be_reaped() {
+fn evm_system_account_should_be_reaped() {
 	new_test_ext().execute_with_ext(|_| {
 		// Check test preconditions.
 		assert!(EvmSystem::account_exists(&bob()));
@@ -290,7 +290,7 @@ fn account_should_be_reaped() {
 }
 
 #[test]
-fn transferring_too_high_value_should_not_panic() {
+fn evm_transferring_too_high_value_should_not_panic() {
 	new_test_ext().execute_with(|| {
 		// Prepare test preconditions.
 		let charlie = H160::from_str("1000000000000000000000000000000000000003").unwrap();
@@ -307,7 +307,7 @@ fn transferring_too_high_value_should_not_panic() {
 }
 
 #[test]
-fn fee_deduction() {
+fn evm_fee_deduction() {
 	new_test_ext().execute_with(|| {
 		let charlie = H160::from_str("1000000000000000000000000000000000000003").unwrap();
 
@@ -331,7 +331,7 @@ fn fee_deduction() {
 }
 
 #[test]
-fn issuance_after_tip() {
+fn evm_issuance_after_tip() {
 	new_test_ext().execute_with(|| {
 		let before_tip = <Test as pallet_evm::Config>::Currency::total_issuance();
 
@@ -362,7 +362,7 @@ fn issuance_after_tip() {
 }
 
 #[test]
-fn refunds_should_work() {
+fn evm_refunds_should_work() {
 	new_test_ext().execute_with(|| {
 		let before_call = EVM::account_basic(&alice()).0.balance;
 		// Gas price is not part of the actual fee calculations anymore, only the base fee.
@@ -393,7 +393,7 @@ fn refunds_should_work() {
 }
 
 #[test]
-fn refunds_and_priority_should_work() {
+fn evm_refunds_and_priority_should_work() {
 	new_test_ext().execute_with(|| {
 		let before_call = EVM::account_basic(&alice()).0.balance;
 		// We deliberately set a base fee + max tip > max fee.
@@ -429,7 +429,7 @@ fn refunds_and_priority_should_work() {
 }
 
 #[test]
-fn call_should_fail_with_priority_greater_than_max_fee() {
+fn evm_call_should_fail_with_priority_greater_than_max_fee() {
 	new_test_ext().execute_with(|| {
 		// Max priority greater than max fee should fail.
 		let tip: u128 = 1_100_000_000;
@@ -455,7 +455,7 @@ fn call_should_fail_with_priority_greater_than_max_fee() {
 }
 
 #[test]
-fn call_should_succeed_with_priority_equal_to_max_fee() {
+fn evm_call_should_succeed_with_priority_equal_to_max_fee() {
 	new_test_ext().execute_with(|| {
 		let tip: u128 = 1_000_000_000;
 		// Mimics the input for pre-eip-1559 transaction types where `gas_price`

--- a/frame/evm-balances/src/tests.rs
+++ b/frame/evm-balances/src/tests.rs
@@ -290,7 +290,7 @@ fn evm_system_account_should_be_reaped() {
 }
 
 #[test]
-fn evm_transferring_too_high_value_should_not_panic() {
+fn evm_balances_transferring_too_high_value_should_not_panic() {
 	new_test_ext().execute_with(|| {
 		// Prepare test preconditions.
 		let charlie = H160::from_str("1000000000000000000000000000000000000003").unwrap();

--- a/frame/evm-balances/src/tests.rs
+++ b/frame/evm-balances/src/tests.rs
@@ -47,6 +47,39 @@ fn account_should_be_reaped() {
 }
 
 #[test]
+fn deposit_into_existing() {
+	new_test_ext().execute_with_ext(|_| {
+		// Check test preconditions.
+		assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
+
+		let deposited_amount = 10;
+
+		// Set block number to enable events.
+		System::set_block_number(1);
+
+		// Invoke the function under test.
+		assert_ok!(EvmBalances::deposit_into_existing(
+			&alice(),
+			deposited_amount
+		));
+
+		// Assert state changes.
+		assert_eq!(
+			EvmBalances::total_balance(&alice()),
+			INIT_BALANCE + deposited_amount
+		);
+		System::assert_has_event(RuntimeEvent::EvmBalances(crate::Event::Deposit {
+			who: alice(),
+			amount: 10,
+		}));
+		assert_eq!(
+			EvmBalances::total_balance(&alice()),
+			INIT_BALANCE + deposited_amount
+		);
+	});
+}
+
+#[test]
 fn fee_deduction() {
 	new_test_ext().execute_with(|| {
 		let charlie = H160::from_str("1000000000000000000000000000000000000003").unwrap();

--- a/frame/evm-balances/src/tests.rs
+++ b/frame/evm-balances/src/tests.rs
@@ -13,18 +13,12 @@ fn basic_setup_works() {
 	new_test_ext().execute_with_ext(|_| {
 		// Check the accounts.
 		assert_eq!(
-			<EvmSystem>::full_account(&alice()),
-			pallet_evm_system::AccountInfo {
-				nonce: 0,
-				data: account_data::AccountData { free: INIT_BALANCE }
-			}
+			<EvmBalances>::account(&alice()),
+			account_data::AccountData { free: INIT_BALANCE }
 		);
 		assert_eq!(
-			<EvmSystem>::full_account(&bob()),
-			pallet_evm_system::AccountInfo {
-				nonce: 0,
-				data: account_data::AccountData { free: INIT_BALANCE }
-			}
+			<EvmBalances>::account(&bob()),
+			account_data::AccountData { free: INIT_BALANCE }
 		);
 
 		// Check the total balance value.

--- a/frame/evm-balances/src/tests.rs
+++ b/frame/evm-balances/src/tests.rs
@@ -37,7 +37,7 @@ fn currency_total_balance_works() {
 #[test]
 fn currency_can_slash_works() {
 	new_test_ext().execute_with_ext(|_| {
-		// Check slashing.
+		// Check possible slashing.
 		assert!(EvmBalances::can_slash(&alice(), 100));
 	});
 }

--- a/frame/evm-balances/src/tests.rs
+++ b/frame/evm-balances/src/tests.rs
@@ -118,6 +118,37 @@ fn slashing_balance_works() {
 }
 
 #[test]
+fn withdraw_balance_works() {
+	new_test_ext().execute_with_ext(|_| {
+		// Check test preconditions.
+		assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
+
+		let withdrawed_amount = 1000;
+
+		// Set block number to enable events.
+		System::set_block_number(1);
+
+		// Invoke the function under test.
+		assert_ok!(EvmBalances::withdraw(
+			&alice(),
+			1000,
+			WithdrawReasons::FEE,
+			ExistenceRequirement::KeepAlive
+		));
+
+		// Assert state changes.
+		assert_eq!(
+			EvmBalances::total_balance(&alice()),
+			INIT_BALANCE - withdrawed_amount
+		);
+		System::assert_has_event(RuntimeEvent::EvmBalances(crate::Event::Withdraw {
+			who: alice(),
+			amount: withdrawed_amount,
+		}));
+	});
+}
+
+#[test]
 fn account_should_be_reaped() {
 	new_test_ext().execute_with_ext(|_| {
 		// Check test preconditions.


### PR DESCRIPTION
## Tasks
- [x] introduce the pallet to operate account data with balances
- [x] implement `Currency` and `Inspect` traits for the pallet required to be used at `pallet-evm`
- [x] set up mock to be used for tests
- [x] implement basic tests to verify logic (balances related tests from `pallet-evm` tests)