### PR TITLE
Support external account provider (#83)

### DIFF
--- a/frame/ethereum/src/mock.rs
+++ b/frame/ethereum/src/mock.rs
@@ -156,6 +156,7 @@ impl AddressMapping<AccountId32> for HashedAddressMapping {
 }
 
 impl pallet_evm::Config for Test {
+	type AccountProvider = pallet_evm::NativeSystemAccountProvider<Self>;
 	type FeeCalculator = FixedGasPrice;
 	type GasWeightMapping = pallet_evm::FixedGasWeightMapping<Self>;
 	type WeightPerGas = WeightPerGas;

--- a/frame/evm/precompile/dispatch/src/lib.rs
+++ b/frame/evm/precompile/dispatch/src/lib.rs
@@ -50,8 +50,8 @@ impl<T, DispatchValidator, DecodeLimit> Precompile for Dispatch<T, DispatchValid
 where
 	T: pallet_evm::Config,
 	T::RuntimeCall: Dispatchable<PostInfo = PostDispatchInfo> + GetDispatchInfo + Decode,
-	<T::RuntimeCall as Dispatchable>::RuntimeOrigin: From<Option<T::AccountId>>,
-	DispatchValidator: DispatchValidateT<T::AccountId, T::RuntimeCall>,
+	<T::RuntimeCall as Dispatchable>::RuntimeOrigin: From<Option<<<T as pallet_evm::Config>::AccountProvider as pallet_evm::AccountProvider>::AccountId>>,
+	DispatchValidator: DispatchValidateT<<<T as pallet_evm::Config>::AccountProvider as pallet_evm::AccountProvider>::AccountId, T::RuntimeCall>,
 	DecodeLimit: Get<u32>,
 {
 	fn execute(handle: &mut impl PrecompileHandle) -> PrecompileResult {

--- a/frame/evm/precompile/dispatch/src/mock.rs
+++ b/frame/evm/precompile/dispatch/src/mock.rs
@@ -139,14 +139,15 @@ parameter_types! {
 	pub WeightPerGas: Weight = Weight::from_parts(20_000, 0);
 }
 impl pallet_evm::Config for Test {
+	type AccountProvider = pallet_evm::NativeSystemAccountProvider<Self>;
 	type FeeCalculator = FixedGasPrice;
 	type GasWeightMapping = pallet_evm::FixedGasWeightMapping<Self>;
 	type WeightPerGas = WeightPerGas;
 
 	type BlockHashMapping = pallet_evm::SubstrateBlockHashMapping<Self>;
-	type CallOrigin = EnsureAddressRoot<Self::AccountId>;
+	type CallOrigin = EnsureAddressRoot<<Self::AccountProvider as pallet_evm::AccountProvider>::AccountId>;
 
-	type WithdrawOrigin = EnsureAddressNever<Self::AccountId>;
+	type WithdrawOrigin = EnsureAddressNever<<Self::AccountProvider as pallet_evm::AccountProvider>::AccountId>;
 	type AddressMapping = IdentityAddressMapping;
 	type Currency = Balances;
 

--- a/frame/evm/src/mock.rs
+++ b/frame/evm/src/mock.rs
@@ -135,14 +135,15 @@ parameter_types! {
 	pub MockPrecompiles: MockPrecompileSet = MockPrecompileSet;
 }
 impl crate::Config for Test {
+	type AccountProvider = crate::NativeSystemAccountProvider<Self>;
 	type FeeCalculator = FixedGasPrice;
 	type GasWeightMapping = crate::FixedGasWeightMapping<Self>;
 	type WeightPerGas = WeightPerGas;
 
 	type BlockHashMapping = crate::SubstrateBlockHashMapping<Self>;
-	type CallOrigin = EnsureAddressRoot<Self::AccountId>;
+	type CallOrigin = EnsureAddressRoot<<Self::AccountProvider as crate::AccountProvider>::AccountId>;
 
-	type WithdrawOrigin = EnsureAddressNever<Self::AccountId>;
+	type WithdrawOrigin = EnsureAddressNever<<Self::AccountProvider as crate::AccountProvider>::AccountId>;
 	type AddressMapping = IdentityAddressMapping;
 	type Currency = Balances;
 

--- a/frame/evm/src/runner/stack.rs
+++ b/frame/evm/src/runner/stack.rs
@@ -18,8 +18,8 @@
 //! EVM stack-based runner.
 
 use crate::{
-	runner::Runner as RunnerT, AccountCodes, AccountCodesMetadata, AccountStorages, AddressMapping,
-	BalanceOf, BlockHashMapping, Config, Error, Event, FeeCalculator, OnChargeEVMTransaction,
+	runner::Runner as RunnerT, AccountCodes, AccountCodesMetadata, AccountProvider, AccountStorages,
+	AddressMapping, BalanceOf, BlockHashMapping, Config, Error, Event, FeeCalculator, OnChargeEVMTransaction,
 	OnCreate, Pallet, RunnerError, Weight,
 };
 use evm::{
@@ -830,7 +830,7 @@ where
 
 	fn inc_nonce(&mut self, address: H160) -> Result<(), ExitError> {
 		let account_id = T::AddressMapping::into_account_id(address);
-		frame_system::Pallet::<T>::inc_account_nonce(&account_id);
+		T::AccountProvider::inc_account_nonce(&account_id);
 		Ok(())
 	}
 

--- a/primitives/evm/src/account_provider.rs
+++ b/primitives/evm/src/account_provider.rs
@@ -1,0 +1,41 @@
+//! Custom account provider logic.
+
+use sp_runtime::traits::AtLeast32Bit;
+
+/// The account provider interface abstraction layer.
+///
+/// Expose account related logic that `pallet_evm` required to control accounts existence
+/// in the network and their transactions uniqueness. By default, the pallet operates native
+/// system accounts records that `frame_system` provides.
+///
+/// The interface allow any custom account provider logic to be used instead of
+/// just using `frame_system` account provider. The accounts records should store nonce value
+/// for each account at least.
+pub trait AccountProvider {
+	/// The account identifier type.
+	///
+	/// Represent the account itself in accounts records.
+	type AccountId;
+	/// Account index (aka nonce) type.
+	///
+	/// The number that helps to ensure that each transaction in the network is unique
+	/// for particular account.
+	type Index: AtLeast32Bit;
+
+	/// Creates a new account in accounts records.
+	///
+	/// The account associated with new created address EVM.
+	fn create_account(who: &Self::AccountId);
+	/// Removes an account from accounts records.
+	///
+	/// The account associated with removed address from EVM.
+	fn remove_account(who: &Self::AccountId);
+	/// Return current account nonce value.
+	///
+	/// Used to represent account basic information in EVM format.
+	fn account_nonce(who: &Self::AccountId) -> Self::Index;
+	/// Increment a particular account's nonce value.
+	///
+	/// Incremented with each new transaction submitted by the account.
+	fn inc_account_nonce(who: &Self::AccountId);
+}

--- a/primitives/evm/src/lib.rs
+++ b/primitives/evm/src/lib.rs
@@ -18,6 +18,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![deny(unused_crate_dependencies)]
 
+mod account_provider;
 mod precompile;
 mod validation;
 
@@ -35,6 +36,7 @@ pub use evm::{
 };
 
 pub use self::{
+	account_provider::AccountProvider,
 	precompile::{
 		Context, ExitError, ExitRevert, ExitSucceed, IsPrecompileResult, LinearCostPrecompile,
 		Precompile, PrecompileFailure, PrecompileHandle, PrecompileOutput, PrecompileResult,

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -321,6 +321,7 @@ parameter_types! {
 }
 
 impl pallet_evm::Config for Runtime {
+	type AccountProvider = pallet_evm::NativeSystemAccountProvider<Self>;
 	type FeeCalculator = BaseFee;
 	type GasWeightMapping = pallet_evm::FixedGasWeightMapping<Self>;
 	type WeightPerGas = WeightPerGas;


### PR DESCRIPTION
* Introduce external account provider into `pallet_evm` (#61)

* Introduce AccountProvider interface

* Apply account provider logic for tests and template

* Fix docs for remove_account method

* Fix missing docs

* Improve docs for account provider trait

* Fix docs for native system account provider

* Move account provider logic to separate mod

* Add details docs for methods

* Move `AccountProvider` interface into `fp-em` (#71)

* Move account provider interface into fp-em

* Implement AccountProvider interface for EvmSystem

* Revert formatter

* Move NativeSystemAccountProvider to pallet-evm