### PR TITLE
Support external account provider (#83) (#92)

### DIFF
--- a/frame/ethereum/src/mock.rs
+++ b/frame/ethereum/src/mock.rs
@@ -160,6 +160,7 @@ impl AddressMapping<AccountId32> for HashedAddressMapping {
 }
 
 impl pallet_evm::Config for Test {
+	type AccountProvider = pallet_evm::NativeSystemAccountProvider<Self>;
 	type FeeCalculator = FixedGasPrice;
 	type GasWeightMapping = pallet_evm::FixedGasWeightMapping<Self>;
 	type WeightPerGas = WeightPerGas;

--- a/frame/evm/precompile/dispatch/src/lib.rs
+++ b/frame/evm/precompile/dispatch/src/lib.rs
@@ -50,8 +50,8 @@ impl<T, DispatchValidator, DecodeLimit> Precompile for Dispatch<T, DispatchValid
 where
 	T: pallet_evm::Config,
 	T::RuntimeCall: Dispatchable<PostInfo = PostDispatchInfo> + GetDispatchInfo + Decode,
-	<T::RuntimeCall as Dispatchable>::RuntimeOrigin: From<Option<T::AccountId>>,
-	DispatchValidator: DispatchValidateT<T::AccountId, T::RuntimeCall>,
+	<T::RuntimeCall as Dispatchable>::RuntimeOrigin: From<Option<<<T as pallet_evm::Config>::AccountProvider as pallet_evm::AccountProvider>::AccountId>>,
+	DispatchValidator: DispatchValidateT<<<T as pallet_evm::Config>::AccountProvider as pallet_evm::AccountProvider>::AccountId, T::RuntimeCall>,
 	DecodeLimit: Get<u32>,
 {
 	fn execute(handle: &mut impl PrecompileHandle) -> PrecompileResult {

--- a/frame/evm/precompile/dispatch/src/mock.rs
+++ b/frame/evm/precompile/dispatch/src/mock.rs
@@ -143,14 +143,15 @@ parameter_types! {
 	pub WeightPerGas: Weight = Weight::from_parts(20_000, 0);
 }
 impl pallet_evm::Config for Test {
+	type AccountProvider = pallet_evm::NativeSystemAccountProvider<Self>;
 	type FeeCalculator = FixedGasPrice;
 	type GasWeightMapping = pallet_evm::FixedGasWeightMapping<Self>;
 	type WeightPerGas = WeightPerGas;
 
 	type BlockHashMapping = pallet_evm::SubstrateBlockHashMapping<Self>;
-	type CallOrigin = EnsureAddressRoot<Self::AccountId>;
+	type CallOrigin = EnsureAddressRoot<<Self::AccountProvider as pallet_evm::AccountProvider>::AccountId>;
 
-	type WithdrawOrigin = EnsureAddressNever<Self::AccountId>;
+	type WithdrawOrigin = EnsureAddressNever<<Self::AccountProvider as pallet_evm::AccountProvider>::AccountId>;
 	type AddressMapping = IdentityAddressMapping;
 	type Currency = Balances;
 

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -96,7 +96,7 @@ use fp_account::AccountId20;
 #[cfg(feature = "std")]
 use fp_evm::GenesisAccount;
 pub use fp_evm::{
-	Account, CallInfo, CreateInfo, ExecutionInfoV2 as ExecutionInfo, FeeCalculator,
+	Account, AccountProvider, CallInfo, CreateInfo, ExecutionInfoV2 as ExecutionInfo, FeeCalculator,
 	InvalidEvmTransactionError, IsPrecompileResult, LinearCostPrecompile, Log, Precompile,
 	PrecompileFailure, PrecompileHandle, PrecompileOutput, PrecompileResult, PrecompileSet,
 	Vicinity,
@@ -120,6 +120,9 @@ pub mod pallet {
 
 	#[pallet::config]
 	pub trait Config: frame_system::Config {
+		/// Account info provider.
+		type AccountProvider: AccountProvider;
+
 		/// Calculator for current gas price.
 		type FeeCalculator: FeeCalculator;
 
@@ -135,12 +138,12 @@ pub mod pallet {
 		/// Allow the origin to call on behalf of given address.
 		type CallOrigin: EnsureAddressOrigin<Self::RuntimeOrigin>;
 		/// Allow the origin to withdraw on behalf of given address.
-		type WithdrawOrigin: EnsureAddressOrigin<Self::RuntimeOrigin, Success = Self::AccountId>;
+		type WithdrawOrigin: EnsureAddressOrigin<Self::RuntimeOrigin, Success = <Self::AccountProvider as AccountProvider>::AccountId>;
 
 		/// Mapping from address to account id.
-		type AddressMapping: AddressMapping<Self::AccountId>;
+		type AddressMapping: AddressMapping<<Self::AccountProvider as AccountProvider>::AccountId>;
 		/// Currency type for withdraw and balance storage.
-		type Currency: Currency<Self::AccountId> + Inspect<Self::AccountId>;
+		type Currency: Currency<<Self::AccountProvider as AccountProvider>::AccountId> + Inspect<<Self::AccountProvider as AccountProvider>::AccountId>;
 
 		/// The overarching event type.
 		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
@@ -535,7 +538,7 @@ pub mod pallet {
 					MAX_ACCOUNT_NONCE,
 					UniqueSaturatedInto::<usize>::unique_saturated_into(account.nonce),
 				) {
-					frame_system::Pallet::<T>::inc_account_nonce(&account_id);
+					T::AccountProvider::inc_account_nonce(&account_id);
 				}
 
 				T::Currency::deposit_creating(&account_id, account.balance.unique_saturated_into());
@@ -563,11 +566,11 @@ pub mod pallet {
 
 /// Type alias for currency balance.
 pub type BalanceOf<T> =
-	<<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
+	<<T as Config>::Currency as Currency<<<T as Config>::AccountProvider as AccountProvider>::AccountId>>::Balance;
 
 /// Type alias for negative imbalance during fees
 type NegativeImbalanceOf<C, T> =
-	<C as Currency<<T as frame_system::Config>::AccountId>>::NegativeImbalance;
+	<C as Currency<<<T as Config>::AccountProvider as AccountProvider>::AccountId>>::NegativeImbalance;
 
 #[derive(
 	Debug,
@@ -792,7 +795,7 @@ impl<T: Config> Pallet<T> {
 	pub fn remove_account(address: &H160) {
 		if <AccountCodes<T>>::contains_key(address) {
 			let account_id = T::AddressMapping::into_account_id(*address);
-			let _ = frame_system::Pallet::<T>::dec_sufficients(&account_id);
+			T::AccountProvider::remove_account(&account_id);
 		}
 
 		<AccountCodes<T>>::remove(address);
@@ -809,7 +812,7 @@ impl<T: Config> Pallet<T> {
 
 		if !<AccountCodes<T>>::contains_key(address) {
 			let account_id = T::AddressMapping::into_account_id(address);
-			let _ = frame_system::Pallet::<T>::inc_sufficients(&account_id);
+			T::AccountProvider::create_account(&account_id);
 		}
 
 		// Update metadata.
@@ -850,7 +853,7 @@ impl<T: Config> Pallet<T> {
 	pub fn account_basic(address: &H160) -> (Account, frame_support::weights::Weight) {
 		let account_id = T::AddressMapping::into_account_id(*address);
 
-		let nonce = frame_system::Pallet::<T>::account_nonce(&account_id);
+		let nonce = T::AccountProvider::account_nonce(&account_id);
 		// keepalive `true` takes into account ExistentialDeposit as part of what's considered liquid balance.
 		let balance =
 			T::Currency::reducible_balance(&account_id, Preservation::Preserve, Fortitude::Polite);
@@ -907,17 +910,17 @@ pub struct EVMCurrencyAdapter<C, OU>(sp_std::marker::PhantomData<(C, OU)>);
 impl<T, C, OU> OnChargeEVMTransaction<T> for EVMCurrencyAdapter<C, OU>
 where
 	T: Config,
-	C: Currency<<T as frame_system::Config>::AccountId>,
+	C: Currency<<<T as Config>::AccountProvider as AccountProvider>::AccountId>,
 	C::PositiveImbalance: Imbalance<
-		<C as Currency<<T as frame_system::Config>::AccountId>>::Balance,
+		<C as Currency<<<T as Config>::AccountProvider as AccountProvider>::AccountId>>::Balance,
 		Opposite = C::NegativeImbalance,
 	>,
 	C::NegativeImbalance: Imbalance<
-		<C as Currency<<T as frame_system::Config>::AccountId>>::Balance,
+		<C as Currency<<<T as Config>::AccountProvider as AccountProvider>::AccountId>>::Balance,
 		Opposite = C::PositiveImbalance,
 	>,
 	OU: OnUnbalanced<NegativeImbalanceOf<C, T>>,
-	U256: UniqueSaturatedInto<<C as Currency<<T as frame_system::Config>::AccountId>>::Balance>,
+	U256: UniqueSaturatedInto<<C as Currency<<<T as Config>::AccountProvider as AccountProvider>::AccountId>>::Balance>,
 {
 	// Kept type as Option to satisfy bound of Default
 	type LiquidityInfo = Option<NegativeImbalanceOf<C, T>>;
@@ -1001,10 +1004,10 @@ where
 impl<T> OnChargeEVMTransaction<T> for ()
 	where
 	T: Config,
-	<T::Currency as Currency<<T as frame_system::Config>::AccountId>>::PositiveImbalance:
-		Imbalance<<T::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance, Opposite = <T::Currency as Currency<<T as frame_system::Config>::AccountId>>::NegativeImbalance>,
-	<T::Currency as Currency<<T as frame_system::Config>::AccountId>>::NegativeImbalance:
-Imbalance<<T::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance, Opposite = <T::Currency as Currency<<T as frame_system::Config>::AccountId>>::PositiveImbalance>,
+	<T::Currency as Currency<<<T as Config>::AccountProvider as AccountProvider>::AccountId>>::PositiveImbalance:
+		Imbalance<<T::Currency as Currency<<<T as Config>::AccountProvider as AccountProvider>::AccountId>>::Balance, Opposite = <T::Currency as Currency<<<T as Config>::AccountProvider as AccountProvider>::AccountId>>::NegativeImbalance>,
+	<T::Currency as Currency<<<T as Config>::AccountProvider as AccountProvider>::AccountId>>::NegativeImbalance:
+Imbalance<<T::Currency as Currency<<<T as Config>::AccountProvider as AccountProvider>::AccountId>>::Balance, Opposite = <T::Currency as Currency<<<T as Config>::AccountProvider as AccountProvider>::AccountId>>::PositiveImbalance>,
 U256: UniqueSaturatedInto<BalanceOf<T>>,
 
 {
@@ -1048,3 +1051,27 @@ impl<T> OnCreate<T> for Tuple {
 		)*)
 	}
 }
+
+/// Native system account provider that `frame_system` provides.
+pub struct NativeSystemAccountProvider<T>(sp_std::marker::PhantomData<T>);
+
+impl<T: frame_system::Config> AccountProvider for NativeSystemAccountProvider<T> {
+	type AccountId = T::AccountId;
+	type Index = T::Index;
+
+	fn account_nonce(who: &Self::AccountId) -> Self::Index {
+		frame_system::Pallet::<T>::account_nonce(&who)
+	}
+
+	fn inc_account_nonce(who: &Self::AccountId) {
+		frame_system::Pallet::<T>::inc_account_nonce(&who)
+	}
+
+	fn create_account(who: &Self::AccountId) {
+		let _ = frame_system::Pallet::<T>::inc_sufficients(&who);
+	}
+	fn remove_account(who: &Self::AccountId) {
+		let _ = frame_system::Pallet::<T>::dec_sufficients(&who);
+	}
+}
+

--- a/frame/evm/src/mock.rs
+++ b/frame/evm/src/mock.rs
@@ -139,14 +139,15 @@ parameter_types! {
 	pub MockPrecompiles: MockPrecompileSet = MockPrecompileSet;
 }
 impl crate::Config for Test {
+	type AccountProvider = crate::NativeSystemAccountProvider<Self>;
 	type FeeCalculator = FixedGasPrice;
 	type GasWeightMapping = crate::FixedGasWeightMapping<Self>;
 	type WeightPerGas = WeightPerGas;
 
 	type BlockHashMapping = crate::SubstrateBlockHashMapping<Self>;
-	type CallOrigin = EnsureAddressRoot<Self::AccountId>;
+	type CallOrigin = EnsureAddressRoot<<Self::AccountProvider as crate::AccountProvider>::AccountId>;
 
-	type WithdrawOrigin = EnsureAddressNever<Self::AccountId>;
+	type WithdrawOrigin = EnsureAddressNever<<Self::AccountProvider as crate::AccountProvider>::AccountId>;
 	type AddressMapping = IdentityAddressMapping;
 	type Currency = Balances;
 

--- a/frame/evm/src/runner/stack.rs
+++ b/frame/evm/src/runner/stack.rs
@@ -48,8 +48,8 @@ use fp_evm::{
 };
 
 use crate::{
-	runner::Runner as RunnerT, AccountCodes, AccountCodesMetadata, AccountStorages, AddressMapping,
-	BalanceOf, BlockHashMapping, Config, Error, Event, FeeCalculator, OnChargeEVMTransaction,
+	runner::Runner as RunnerT, AccountCodes, AccountCodesMetadata, AccountProvider, AccountStorages,
+	AddressMapping, BalanceOf, BlockHashMapping, Config, Error, Event, FeeCalculator, OnChargeEVMTransaction,
 	OnCreate, Pallet, RunnerError,
 };
 
@@ -838,7 +838,7 @@ where
 
 	fn inc_nonce(&mut self, address: H160) -> Result<(), ExitError> {
 		let account_id = T::AddressMapping::into_account_id(address);
-		frame_system::Pallet::<T>::inc_account_nonce(&account_id);
+		T::AccountProvider::inc_account_nonce(&account_id);
 		Ok(())
 	}
 

--- a/primitives/evm/src/account_provider.rs
+++ b/primitives/evm/src/account_provider.rs
@@ -1,0 +1,41 @@
+//! Custom account provider logic.
+
+use sp_runtime::traits::AtLeast32Bit;
+
+/// The account provider interface abstraction layer.
+///
+/// Expose account related logic that `pallet_evm` required to control accounts existence
+/// in the network and their transactions uniqueness. By default, the pallet operates native
+/// system accounts records that `frame_system` provides.
+///
+/// The interface allow any custom account provider logic to be used instead of
+/// just using `frame_system` account provider. The accounts records should store nonce value
+/// for each account at least.
+pub trait AccountProvider {
+	/// The account identifier type.
+	///
+	/// Represent the account itself in accounts records.
+	type AccountId;
+	/// Account index (aka nonce) type.
+	///
+	/// The number that helps to ensure that each transaction in the network is unique
+	/// for particular account.
+	type Index: AtLeast32Bit;
+
+	/// Creates a new account in accounts records.
+	///
+	/// The account associated with new created address EVM.
+	fn create_account(who: &Self::AccountId);
+	/// Removes an account from accounts records.
+	///
+	/// The account associated with removed address from EVM.
+	fn remove_account(who: &Self::AccountId);
+	/// Return current account nonce value.
+	///
+	/// Used to represent account basic information in EVM format.
+	fn account_nonce(who: &Self::AccountId) -> Self::Index;
+	/// Increment a particular account's nonce value.
+	///
+	/// Incremented with each new transaction submitted by the account.
+	fn inc_account_nonce(who: &Self::AccountId);
+}

--- a/primitives/evm/src/lib.rs
+++ b/primitives/evm/src/lib.rs
@@ -18,6 +18,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![deny(unused_crate_dependencies)]
 
+mod account_provider;
 mod precompile;
 mod validation;
 
@@ -36,6 +37,7 @@ pub use evm::{
 };
 
 pub use self::{
+	account_provider::AccountProvider,
 	precompile::{
 		Context, ExitError, ExitRevert, ExitSucceed, IsPrecompileResult, LinearCostPrecompile,
 		Precompile, PrecompileFailure, PrecompileHandle, PrecompileOutput, PrecompileResult,

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -323,6 +323,7 @@ parameter_types! {
 }
 
 impl pallet_evm::Config for Runtime {
+	type AccountProvider = pallet_evm::NativeSystemAccountProvider<Self>;
 	type FeeCalculator = BaseFee;
 	type GasWeightMapping = pallet_evm::FixedGasWeightMapping<Self>;
 	type WeightPerGas = WeightPerGas;


### PR DESCRIPTION
* Introduce external account provider into `pallet_evm` (#61)

* Introduce AccountProvider interface

* Apply account provider logic for tests and template

* Fix docs for remove_account method

* Fix missing docs

* Improve docs for account provider trait

* Fix docs for native system account provider

* Move account provider logic to separate mod

* Add details docs for methods

* Move `AccountProvider` interface into `fp-em` (#71)

* Move account provider interface into fp-em

* Implement AccountProvider interface for EvmSystem

* Revert formatter

* Move NativeSystemAccountProvider to pallet-evm