### PR TITLE
Fungible conformance tests: Inspect and Mutate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5479,6 +5479,7 @@ dependencies = [
  "pallet-evm-system",
  "pallet-timestamp",
  "parity-scale-codec",
+ "paste",
  "scale-info",
  "sp-core",
  "sp-io",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ log = { version = "0.4.17", default-features = false }
 mockall = "0.11"
 parity-db = "0.4.8"
 parking_lot = "0.12.1"
+paste = "1.0"
 rlp = { version = "0.5", default-features = false }
 scale-codec = { package = "parity-scale-codec", version = "3.2.1", default-features = false, features = ["derive"] }
 scale-info = { version = "2.3.1", default-features = false, features = ["derive"] }

--- a/frame/evm-balances/Cargo.toml
+++ b/frame/evm-balances/Cargo.toml
@@ -24,6 +24,7 @@ fp-evm = { workspace = true }
 pallet-evm = { workspace = true }
 pallet-evm-system = { workspace = true }
 pallet-timestamp = { workspace = true }
+paste = { workspace = true }
 sp-core = { workspace = true }
 sp-io = { workspace = true }
 

--- a/frame/evm-balances/src/mock.rs
+++ b/frame/evm-balances/src/mock.rs
@@ -24,7 +24,7 @@ use frame_support::{
 	traits::{ConstU32, ConstU64, FindAuthor},
 	weights::Weight,
 };
-use pallet_evm::{EnsureAddressNever, FixedGasWeightMapping, IdentityAddressMapping};
+use pallet_evm::{AddressMapping, EnsureAddressNever, FixedGasWeightMapping};
 use sp_core::{H160, H256, U256};
 use sp_runtime::{
 	generic,
@@ -37,12 +37,33 @@ use crate::{self as pallet_evm_balances, *};
 
 pub(crate) const INIT_BALANCE: u64 = 10_000_000_000_000_000;
 
-pub(crate) fn alice() -> H160 {
-	H160::from_str("1000000000000000000000000000000000000000").unwrap()
+/// Alice account.
+pub(crate) fn alice() -> u64 {
+	5234
 }
 
-pub(crate) fn bob() -> H160 {
-	H160::from_str("2000000000000000000000000000000000000000").unwrap()
+/// Alice H160 account.
+pub(crate) fn alice_h160() -> H160 {
+	H160::from_low_u64_be(alice())
+}
+
+/// Bob account.
+pub(crate) fn bob() -> u64 {
+	4325
+}
+
+/// Bob H160 account.
+pub(crate) fn bob_h160() -> H160 {
+	H160::from_low_u64_be(bob())
+}
+
+/// H160 into u64 address mapper.
+pub struct H160IntoU64;
+
+impl AddressMapping<u64> for H160IntoU64 {
+	fn into_account_id(address: H160) -> u64 {
+		address.to_low_u64_be()
+	}
 }
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
@@ -91,7 +112,7 @@ impl frame_system::Config for Test {
 
 impl pallet_evm_system::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
-	type AccountId = H160;
+	type AccountId = u64;
 	type Index = u64;
 	type AccountData = AccountData<u64>;
 	type OnNewAccount = ();
@@ -100,7 +121,7 @@ impl pallet_evm_system::Config for Test {
 
 impl pallet_evm_balances::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
-	type AccountId = H160;
+	type AccountId = u64;
 	type Balance = u64;
 	type ExistentialDeposit = ConstU64<1>;
 	type AccountStore = EvmSystem;
@@ -156,7 +177,7 @@ impl pallet_evm::Config for Test {
 		EnsureAddressNever<<Self::AccountProvider as pallet_evm::AccountProvider>::AccountId>;
 	type WithdrawOrigin =
 		EnsureAddressNever<<Self::AccountProvider as pallet_evm::AccountProvider>::AccountId>;
-	type AddressMapping = IdentityAddressMapping;
+	type AddressMapping = H160IntoU64;
 	type Currency = EvmBalances;
 	type RuntimeEvent = RuntimeEvent;
 	type PrecompilesType = ();
@@ -186,8 +207,8 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 					nonce: Default::default(),
 					storage: Default::default(),
 				};
-				map.insert(alice(), init_genesis_account.clone());
-				map.insert(bob(), init_genesis_account);
+				map.insert(alice_h160(), init_genesis_account.clone());
+				map.insert(bob_h160(), init_genesis_account);
 				map
 			},
 		},

--- a/frame/evm-balances/src/tests/currency.rs
+++ b/frame/evm-balances/src/tests/currency.rs
@@ -1,9 +1,7 @@
 //! Tests regarding the functionality of the `Currency` trait set implementations.
 
 use frame_support::{assert_noop, assert_ok, traits::Currency};
-use sp_core::H160;
 use sp_runtime::TokenError;
-use sp_std::str::FromStr;
 
 use crate::{mock::*, *};
 
@@ -339,7 +337,7 @@ fn deposit_into_existing_fails_overflow() {
 #[test]
 fn deposit_into_existing_fails_dead_account() {
 	new_test_ext().execute_with_ext(|_| {
-		let charlie = H160::from_str("1000000000000000000000000000000000000003").unwrap();
+		let charlie = 3;
 
 		// Check test preconditions.
 		assert_eq!(EvmBalances::total_balance(&charlie), 0);
@@ -358,7 +356,7 @@ fn deposit_into_existing_fails_dead_account() {
 fn deposit_creating_works() {
 	new_test_ext().execute_with_ext(|_| {
 		// Prepare test preconditions.
-		let charlie = H160::from_str("1000000000000000000000000000000000000003").unwrap();
+		let charlie = 3;
 		let deposited_amount = 10;
 		assert!(!EvmSystem::account_exists(&charlie));
 
@@ -493,7 +491,7 @@ fn withdraw_fails_expendability() {
 fn make_free_balance_be_works() {
 	new_test_ext().execute_with_ext(|_| {
 		// Prepare test preconditions.
-		let charlie = H160::from_str("1000000000000000000000000000000000000003").unwrap();
+		let charlie = 3;
 		let made_free_balance = 100;
 
 		// Check test preconditions.
@@ -537,8 +535,8 @@ fn evm_system_account_should_be_reaped() {
 fn transferring_too_high_value_should_not_panic() {
 	new_test_ext().execute_with_ext(|_| {
 		// Prepare test preconditions.
-		let charlie = H160::from_str("1000000000000000000000000000000000000003").unwrap();
-		let eve = H160::from_str("1000000000000000000000000000000000000004").unwrap();
+		let charlie = 3;
+		let eve = 4;
 		EvmBalances::make_free_balance_be(&charlie, u64::MAX);
 		EvmBalances::make_free_balance_be(&eve, 1);
 

--- a/frame/evm-balances/src/tests/fungible.rs
+++ b/frame/evm-balances/src/tests/fungible.rs
@@ -7,9 +7,7 @@ use frame_support::{
 		tokens::Precision,
 	},
 };
-use sp_core::H160;
 use sp_runtime::TokenError;
-use sp_std::str::FromStr;
 
 use crate::{mock::*, *};
 
@@ -779,8 +777,8 @@ fn transfer_fails_not_expendable() {
 fn transfer_fails_underflow() {
 	new_test_ext().execute_with_ext(|_| {
 		// Prepare test preconditions.
-		let charlie = H160::from_str("1000000000000000000000000000000000000003").unwrap();
-		let eve = H160::from_str("1000000000000000000000000000000000000004").unwrap();
+		let charlie = 3;
+		let eve = 4;
 		EvmBalances::set_balance(&charlie, u64::MAX);
 		EvmBalances::set_balance(&eve, 1);
 
@@ -880,7 +878,7 @@ fn deposit_flow_works() {
 #[test]
 fn deposit_works_new_account() {
 	new_test_ext().execute_with_ext(|_| {
-		let charlie = H160::from_str("1000000000000000000000000000000000000003").unwrap();
+		let charlie = 3;
 
 		// Check test preconditions.
 		assert_eq!(EvmBalances::total_balance(&charlie), 0);

--- a/frame/evm-balances/src/tests/fungible_conformance.rs
+++ b/frame/evm-balances/src/tests/fungible_conformance.rs
@@ -1,0 +1,66 @@
+use frame_support::traits::fungible::{conformance_tests, Inspect, Mutate};
+use paste::paste;
+
+use crate::{mock::*, *};
+
+macro_rules! run_tests {
+    ($path:path, $($name:ident),*) => {
+		$(
+			paste! {
+				#[test]
+				fn [< $name _dust_trap_on >]() {
+					let trap_account = 11;
+					new_test_ext().execute_with_ext(|_| {
+						EvmBalances::set_balance(&trap_account, EvmBalances::minimum_balance());
+						$path::$name::<
+							EvmBalances,
+							<Test as Config>::AccountId,
+						>(Some(trap_account));
+					});
+				}
+
+				#[test]
+				fn [< $name _dust_trap_off >]() {
+					new_test_ext().execute_with_ext(|_| {
+						$path::$name::<
+							EvmBalances,
+							<Test as Config>::AccountId,
+						>(None);
+					});
+				}
+			}
+		)*
+	};
+	($path:path) => {
+		run_tests!(
+			$path,
+			mint_into_success,
+			mint_into_overflow,
+			mint_into_below_minimum,
+			burn_from_exact_success,
+			burn_from_best_effort_success,
+			burn_from_exact_insufficient_funds,
+			restore_success,
+			restore_overflow,
+			restore_below_minimum,
+			shelve_success,
+			shelve_insufficient_funds,
+			transfer_success,
+			transfer_expendable_all,
+			transfer_expendable_dust,
+			transfer_protect_preserve,
+			set_balance_mint_success,
+			set_balance_burn_success,
+			can_deposit_success,
+			can_deposit_below_minimum,
+			can_deposit_overflow,
+			can_withdraw_success,
+			can_withdraw_reduced_to_zero,
+			can_withdraw_balance_low,
+			reducible_balance_expendable,
+			reducible_balance_protect_preserve
+		);
+	};
+}
+
+run_tests!(conformance_tests::inspect_mutate);

--- a/frame/evm-balances/src/tests/mod.rs
+++ b/frame/evm-balances/src/tests/mod.rs
@@ -4,12 +4,12 @@ use frame_support::{assert_ok, traits::Currency, weights::Weight};
 use pallet_evm::{FeeCalculator, FixedGasWeightMapping, GasWeightMapping, Runner};
 use sp_core::{H160, U256};
 use sp_runtime::traits::UniqueSaturatedInto;
-use sp_std::str::FromStr;
 
 use crate::{mock::*, *};
 
 mod currency;
 mod fungible;
+mod fungible_conformance;
 
 #[test]
 fn basic_setup_works() {
@@ -29,7 +29,7 @@ fn basic_setup_works() {
 #[test]
 fn evm_fee_deduction() {
 	new_test_ext().execute_with_ext(|_| {
-		let charlie = H160::from_str("1000000000000000000000000000000000000003").unwrap();
+		let charlie = 3;
 
 		// Seed account
 		let _ = <Test as pallet_evm::Config>::Currency::deposit_creating(&charlie, 100);
@@ -38,14 +38,14 @@ fn evm_fee_deduction() {
 		// Deduct fees as 10 units
 		let imbalance =
 			<<Test as pallet_evm::Config>::OnChargeTransaction as pallet_evm::OnChargeEVMTransaction<Test>>::withdraw_fee(
-				&charlie,
+				&H160::from_low_u64_be(charlie),
 				U256::from(10),
 			)
 			.unwrap();
 		assert_eq!(EvmBalances::free_balance(&charlie), 90);
 
 		// Refund fees as 5 units
-		<<Test as pallet_evm::Config>::OnChargeTransaction as pallet_evm::OnChargeEVMTransaction<Test>>::correct_and_deposit_fee(&charlie, U256::from(5), U256::from(5), imbalance);
+		<<Test as pallet_evm::Config>::OnChargeTransaction as pallet_evm::OnChargeEVMTransaction<Test>>::correct_and_deposit_fee(&H160::from_low_u64_be(charlie), U256::from(5), U256::from(5), imbalance);
 		assert_eq!(EvmBalances::free_balance(&charlie), 95);
 	});
 }
@@ -59,8 +59,8 @@ fn evm_issuance_after_tip() {
 		let weight_limit = FixedGasWeightMapping::<Test>::gas_to_weight(gas_limit, true);
 
 		assert_ok!(<Test as pallet_evm::Config>::Runner::call(
-			alice(),
-			bob(),
+			alice_h160(),
+			bob_h160(),
 			Vec::new(),
 			U256::from(1),
 			gas_limit,
@@ -89,7 +89,7 @@ fn evm_issuance_after_tip() {
 #[test]
 fn evm_refunds_should_work() {
 	new_test_ext().execute_with_ext(|_| {
-		let before_call = EVM::account_basic(&alice()).0.balance;
+		let before_call = EVM::account_basic(&alice_h160()).0.balance;
 		// Gas price is not part of the actual fee calculations anymore, only the base fee.
 		//
 		// Because we first deduct max_fee_per_gas * gas_limit (2_000_000_000 * 1000000) we need
@@ -99,8 +99,8 @@ fn evm_refunds_should_work() {
 		let weight_limit = FixedGasWeightMapping::<Test>::gas_to_weight(gas_limit, true);
 
 		let _ = <Test as pallet_evm::Config>::Runner::call(
-			alice(),
-			bob(),
+			alice_h160(),
+			bob_h160(),
 			Vec::new(),
 			U256::from(1),
 			gas_limit,
@@ -117,7 +117,7 @@ fn evm_refunds_should_work() {
 
 		let (base_fee, _) = <Test as pallet_evm::Config>::FeeCalculator::min_gas_price();
 		let total_cost = (U256::from(21_000) * base_fee) + U256::from(1);
-		let after_call = EVM::account_basic(&alice()).0.balance;
+		let after_call = EVM::account_basic(&alice_h160()).0.balance;
 		assert_eq!(after_call, before_call - total_cost);
 	});
 }
@@ -125,7 +125,7 @@ fn evm_refunds_should_work() {
 #[test]
 fn evm_refunds_and_priority_should_work() {
 	new_test_ext().execute_with_ext(|_| {
-		let before_call = EVM::account_basic(&alice()).0.balance;
+		let before_call = EVM::account_basic(&alice_h160()).0.balance;
 		// We deliberately set a base fee + max tip > max fee.
 		// The effective priority tip will be 1GWEI instead 1.5GWEI:
 		// 		(max_fee_per_gas - base_fee).min(max_priority_fee)
@@ -138,8 +138,8 @@ fn evm_refunds_and_priority_should_work() {
 		let weight_limit = FixedGasWeightMapping::<Test>::gas_to_weight(gas_limit, true);
 
 		let _ = <Test as pallet_evm::Config>::Runner::call(
-			alice(),
-			bob(),
+			alice_h160(),
+			bob_h160(),
 			Vec::new(),
 			U256::from(1),
 			gas_limit,
@@ -157,7 +157,7 @@ fn evm_refunds_and_priority_should_work() {
 		let (base_fee, _) = <Test as pallet_evm::Config>::FeeCalculator::min_gas_price();
 		let actual_tip = (max_fee_per_gas - base_fee).min(tip) * used_gas;
 		let total_cost = (used_gas * base_fee) + U256::from(actual_tip) + U256::from(1);
-		let after_call = EVM::account_basic(&alice()).0.balance;
+		let after_call = EVM::account_basic(&alice_h160()).0.balance;
 		// The tip is deducted but never refunded to the caller.
 		assert_eq!(after_call, before_call - total_cost);
 	});
@@ -173,8 +173,8 @@ fn evm_call_should_fail_with_priority_greater_than_max_fee() {
 		let weight_limit = FixedGasWeightMapping::<Test>::gas_to_weight(gas_limit, true);
 
 		let result = <Test as pallet_evm::Config>::Runner::call(
-			alice(),
-			bob(),
+			alice_h160(),
+			bob_h160(),
 			Vec::new(),
 			U256::from(1),
 			gas_limit,
@@ -205,8 +205,8 @@ fn evm_call_should_succeed_with_priority_equal_to_max_fee() {
 		// Mimics the input for pre-eip-1559 transaction types where `gas_price`
 		// is used for both `max_fee_per_gas` and `max_priority_fee_per_gas`.
 		let result = <Test as pallet_evm::Config>::Runner::call(
-			alice(),
-			bob(),
+			alice_h160(),
+			bob_h160(),
 			Vec::new(),
 			U256::from(1),
 			gas_limit,


### PR DESCRIPTION
Changes to add https://github.com/paritytech/substrate/pull/13852 tests.

`pallet-evm-balances`
```
running 128 tests
test mock::__construct_runtime_integrity_test::runtime_integrity_tests ... ok
test tests::basic_setup_works ... ok
test tests::currency::deposit_creating_works ... ok
test tests::currency::burn_works ... ok
test tests::currency::can_slash_works ... ok
test tests::currency::deactivate_reactivate_works ... ok
test tests::currency::deposit_into_existing_works ... ok
test tests::currency::deposit_into_existing_fails_dead_account ... ok
test tests::currency::deposit_into_existing_fails_overflow ... ok
test tests::currency::active_issuance_works ... ok
test tests::currency::evm_system_account_should_be_reaped ... ok
test tests::currency::free_balance_works ... ok
test tests::currency::issue_works ... ok
test tests::currency::minimum_balance_works ... ok
test tests::currency::make_free_balance_be_works ... ok
test tests::currency::slash_works ... ok
test tests::currency::slash_works_full_balance ... ok
test tests::currency::transfer_works_full_balance ... ok
test tests::currency::total_issuance_works ... ok
test tests::currency::transfer_fails_funds_unavailable ... ok
test tests::currency::transfer_fails_not_expendable ... ok
test tests::currency::transfer_works ... ok
test tests::currency::total_balance_works ... ok
test tests::currency::transferring_too_high_value_should_not_panic ... ok
test tests::currency::withdraw_fails_expendability ... ok
test tests::currency::withdraw_fails_insufficient_balance ... ok
test tests::currency::withdraw_works ... ok
test tests::currency::withdraw_works_full_balance ... ok
test tests::evm_call_should_fail_with_priority_greater_than_max_fee ... ok
test tests::evm_call_should_succeed_with_priority_equal_to_max_fee ... ok
test tests::evm_fee_deduction ... ok
test tests::evm_issuance_after_tip ... ok
test tests::fungible::burn_from_works_best_effort ... ok
test tests::evm_refunds_should_work ... ok
test tests::fungible::active_issuance_works ... ok
test tests::fungible::balance_works ... ok
test tests::fungible::burn_from_fails_funds_unavailable ... ok
test tests::fungible::burn_from_works ... ok
test tests::evm_refunds_and_priority_should_work ... ok
test tests::fungible::burn_from_works_exact_full_balance ... ok
test tests::fungible::can_deposit_works_overflow ... ok
test tests::fungible::can_deposit_works_success ... ok
test tests::fungible::can_withdraw_works_reduced_to_zero ... ok
test tests::fungible::can_withdraw_works_balance_low ... ok
test tests::fungible::can_withdraw_works_success ... ok
test tests::fungible::can_withdraw_works_underflow ... ok
test tests::fungible::deactivate_reactivate_works ... ok
test tests::fungible::decrease_balance_fails_funds_unavailable ... ok
test tests::fungible::decrease_balance_works_best_effort_preserve ... ok
test tests::fungible::decrease_balance_works_exact_expendable ... ok
test tests::fungible::deposit_flow_works ... ok
test tests::fungible::increase_balance_fails_overflow ... ok
test tests::fungible::decrease_balance_works_full_balance ... ok
test tests::fungible::deposit_works_new_account ... ok
test tests::fungible::increase_balance_works_best_effort ... ok
test tests::fungible::reducable_balance_works ... ok
test tests::fungible::increase_balance_works ... ok
test tests::fungible::minimum_balance_works ... ok
test tests::fungible::mint_into_fails_overflow ... ok
test tests::fungible::mint_into_works ... ok
test tests::fungible::issue_works ... ok
test tests::fungible::rescind_works ... ok
test tests::fungible::shelve_fails_funds_unavailable ... ok
test tests::fungible::shelve_works_exact_full_balance ... ok
test tests::fungible::set_total_issuance_works ... ok
test tests::fungible::shelve_works ... ok
test tests::fungible::restore_works ... ok
test tests::fungible::restore_fails_overflow ... ok
test tests::fungible::total_balance_works ... ok
test tests::fungible::total_issuance_works ... ok
test tests::fungible::transfer_fails_funds_unavailable ... ok
test tests::fungible::transfer_fails_not_expendable ... ok
test tests::fungible::transfer_fails_underflow ... ok
test tests::fungible::transfer_works ... ok
test tests::fungible::transfer_works_full_balance ... ok
test tests::fungible::withdraw_works_full_balance ... ok
test tests::fungible::write_balance_works ... ok
test tests::fungible_conformance::burn_from_exact_success_dust_trap_off ... ok
test tests::fungible_conformance::burn_from_best_effort_success_dust_trap_off ... ok
test tests::fungible_conformance::burn_from_best_effort_success_dust_trap_on ... ok
test tests::fungible_conformance::burn_from_exact_insufficient_funds_dust_trap_off ... ok
test tests::fungible_conformance::burn_from_exact_insufficient_funds_dust_trap_on ... ok
test tests::fungible::withdraw_works ... ok
test tests::fungible_conformance::burn_from_exact_success_dust_trap_on ... ok
test tests::fungible_conformance::can_deposit_below_minimum_dust_trap_off ... ok
test tests::fungible_conformance::can_deposit_below_minimum_dust_trap_on ... ok
test tests::fungible_conformance::can_deposit_overflow_dust_trap_off ... ok
test tests::fungible_conformance::can_deposit_overflow_dust_trap_on ... ok
test tests::fungible_conformance::can_deposit_success_dust_trap_off ... ok
test tests::fungible_conformance::can_deposit_success_dust_trap_on ... ok
test tests::fungible_conformance::can_withdraw_balance_low_dust_trap_off ... ok
test tests::fungible_conformance::can_withdraw_balance_low_dust_trap_on ... ok
test tests::fungible_conformance::can_withdraw_reduced_to_zero_dust_trap_off ... ok
test tests::fungible_conformance::can_withdraw_reduced_to_zero_dust_trap_on ... ok
test tests::fungible_conformance::can_withdraw_success_dust_trap_off ... ok
test tests::fungible_conformance::can_withdraw_success_dust_trap_on ... ok
test tests::fungible_conformance::mint_into_below_minimum_dust_trap_off ... ok
test tests::fungible_conformance::mint_into_below_minimum_dust_trap_on ... ok
test tests::fungible_conformance::mint_into_overflow_dust_trap_off ... ok
test tests::fungible_conformance::mint_into_overflow_dust_trap_on ... ok
test tests::fungible_conformance::mint_into_success_dust_trap_off ... ok
test tests::fungible_conformance::mint_into_success_dust_trap_on ... ok
test tests::fungible_conformance::reducible_balance_expendable_dust_trap_off ... ok
test tests::fungible_conformance::reducible_balance_expendable_dust_trap_on ... ok
test tests::fungible_conformance::reducible_balance_protect_preserve_dust_trap_off ... ok
test tests::fungible_conformance::reducible_balance_protect_preserve_dust_trap_on ... ok
test tests::fungible_conformance::restore_below_minimum_dust_trap_off ... ok
test tests::fungible_conformance::restore_below_minimum_dust_trap_on ... ok
test tests::fungible_conformance::restore_overflow_dust_trap_off ... ok
test tests::fungible_conformance::restore_overflow_dust_trap_on ... ok
test tests::fungible_conformance::restore_success_dust_trap_off ... ok
test tests::fungible_conformance::restore_success_dust_trap_on ... ok
test tests::fungible_conformance::set_balance_burn_success_dust_trap_off ... ok
test tests::fungible_conformance::set_balance_burn_success_dust_trap_on ... ok
test tests::fungible_conformance::set_balance_mint_success_dust_trap_off ... ok
test tests::fungible_conformance::set_balance_mint_success_dust_trap_on ... ok
test tests::fungible_conformance::shelve_insufficient_funds_dust_trap_off ... ok
test tests::fungible_conformance::shelve_insufficient_funds_dust_trap_on ... ok
test tests::fungible_conformance::shelve_success_dust_trap_off ... ok
test tests::fungible_conformance::shelve_success_dust_trap_on ... ok
test tests::fungible_conformance::transfer_expendable_all_dust_trap_off ... ok
test tests::fungible_conformance::transfer_expendable_all_dust_trap_on ... ok
test tests::fungible_conformance::transfer_expendable_dust_dust_trap_off ... ok
test tests::fungible_conformance::transfer_expendable_dust_dust_trap_on ... ok
test tests::fungible_conformance::transfer_protect_preserve_dust_trap_off ... ok
test tests::fungible_conformance::transfer_protect_preserve_dust_trap_on ... ok
test tests::fungible_conformance::transfer_success_dust_trap_off ... ok
test tests::fungible_conformance::transfer_success_dust_trap_on ... ok

test result: ok. 128 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.05s
```