### PR TITLE
Fix removing account logic at `pallet-evm-system` (#111)

### DIFF
--- a/frame/evm-balances/src/tests/fungible.rs
+++ b/frame/evm-balances/src/tests/fungible.rs
@@ -11,7 +11,7 @@ use sp_core::H160;
 use sp_runtime::TokenError;
 use sp_std::str::FromStr;
 
-use crate::{mock::*, *};
+use crate::{mock::*, tests::assert_total_issuance_invariant, *};
 
 #[test]
 fn total_issuance_works() {
@@ -355,6 +355,8 @@ fn deactivate_reactivate_works() {
 		EvmBalances::reactivate(40);
 		// Assert state changes.
 		assert_eq!(<InactiveIssuance<Test>>::get(), 60);
+
+		assert_total_issuance_invariant();
 	});
 }
 
@@ -386,6 +388,8 @@ fn mint_into_works() {
 			who: alice(),
 			amount: minted_balance,
 		}));
+
+		assert_total_issuance_invariant();
 	});
 }
 
@@ -438,6 +442,8 @@ fn burn_from_works() {
 			who: alice(),
 			amount: burned_balance,
 		}));
+
+		assert_total_issuance_invariant();
 	});
 }
 
@@ -472,6 +478,8 @@ fn burn_from_works_best_effort() {
 		System::assert_has_event(RuntimeEvent::EvmSystem(
 			pallet_evm_system::Event::KilledAccount { account: alice() },
 		));
+
+		assert_total_issuance_invariant();
 	});
 }
 
@@ -506,6 +514,8 @@ fn burn_from_works_exact_full_balance() {
 		System::assert_has_event(RuntimeEvent::EvmSystem(
 			pallet_evm_system::Event::KilledAccount { account: alice() },
 		));
+
+		assert_total_issuance_invariant();
 	});
 }
 
@@ -562,6 +572,8 @@ fn shelve_works() {
 			who: alice(),
 			amount: shelved_balance,
 		}));
+
+		assert_total_issuance_invariant();
 	});
 }
 
@@ -591,6 +603,8 @@ fn shelve_works_exact_full_balance() {
 		System::assert_has_event(RuntimeEvent::EvmSystem(
 			pallet_evm_system::Event::KilledAccount { account: alice() },
 		));
+
+		assert_total_issuance_invariant();
 	});
 }
 
@@ -642,6 +656,8 @@ fn restore_works() {
 			who: alice(),
 			amount: restored_balance,
 		}));
+
+		assert_total_issuance_invariant();
 	});
 }
 
@@ -694,6 +710,8 @@ fn transfer_works() {
 			to: bob(),
 			amount: transfered_amount,
 		}));
+
+		assert_total_issuance_invariant();
 	});
 }
 
@@ -734,6 +752,8 @@ fn transfer_works_full_balance() {
 		System::assert_has_event(RuntimeEvent::EvmSystem(
 			pallet_evm_system::Event::KilledAccount { account: alice() },
 		));
+
+		assert_total_issuance_invariant();
 	});
 }
 
@@ -817,6 +837,8 @@ fn rescind_works() {
 		System::assert_has_event(RuntimeEvent::EvmBalances(Event::Rescinded {
 			amount: rescinded_balance,
 		}));
+
+		assert_total_issuance_invariant();
 	});
 }
 
@@ -844,6 +866,8 @@ fn issue_works() {
 		System::assert_has_event(RuntimeEvent::EvmBalances(Event::Issued {
 			amount: issued_balance,
 		}));
+
+		assert_total_issuance_invariant();
 	});
 }
 
@@ -874,6 +898,8 @@ fn deposit_flow_works() {
 
 		let _ = EvmBalances::settle(&bob(), debt, Preservation::Expendable);
 		assert_eq!(EvmBalances::total_issuance(), 2 * INIT_BALANCE);
+
+		assert_total_issuance_invariant();
 	});
 }
 
@@ -906,6 +932,8 @@ fn deposit_works_new_account() {
 		System::assert_has_event(RuntimeEvent::EvmSystem(
 			pallet_evm_system::Event::NewAccount { account: charlie },
 		));
+
+		assert_total_issuance_invariant();
 	});
 }
 
@@ -942,6 +970,8 @@ fn withdraw_works() {
 		assert_eq!(EvmBalances::total_issuance(), 2 * INIT_BALANCE);
 		let _ = EvmBalances::resolve(&bob(), credit);
 		assert_eq!(EvmBalances::total_issuance(), 2 * INIT_BALANCE);
+
+		assert_total_issuance_invariant();
 	});
 }
 
@@ -982,5 +1012,7 @@ fn withdraw_works_full_balance() {
 		assert_eq!(EvmBalances::total_issuance(), 2 * INIT_BALANCE);
 		let _ = EvmBalances::resolve(&bob(), credit);
 		assert_eq!(EvmBalances::total_issuance(), 2 * INIT_BALANCE);
+
+		assert_total_issuance_invariant();
 	});
 }

--- a/frame/evm-system/src/tests.rs
+++ b/frame/evm-system/src/tests.rs
@@ -2,7 +2,7 @@
 
 use sp_std::str::FromStr;
 
-use frame_support::{assert_noop, assert_ok};
+use frame_support::{assert_noop, assert_storage_noop};
 use mockall::predicate;
 use sp_core::H160;
 
@@ -30,7 +30,10 @@ fn create_account_works() {
 			.return_const(());
 
 		// Invoke the function under test.
-		assert_ok!(EvmSystem::create_account(&account_id));
+		assert_eq!(
+			EvmSystem::create_account(&account_id),
+			AccountCreationOutcome::Created
+		);
 
 		// Assert state changes.
 		assert!(EvmSystem::account_exists(&account_id));
@@ -52,10 +55,10 @@ fn create_account_fails() {
 		<Account<Test>>::insert(account_id.clone(), AccountInfo::<_, _>::default());
 
 		// Invoke the function under test.
-		assert_noop!(
+		assert_storage_noop!(assert_eq!(
 			EvmSystem::create_account(&account_id),
-			Error::<Test>::AccountAlreadyExist
-		);
+			AccountCreationOutcome::AlreadyExists
+		));
 	});
 }
 
@@ -79,7 +82,10 @@ fn remove_account_works() {
 			.return_const(());
 
 		// Invoke the function under test.
-		assert_ok!(EvmSystem::remove_account(&account_id));
+		assert_eq!(
+			EvmSystem::remove_account(&account_id),
+			AccountRemovalOutcome::Reaped
+		);
 
 		// Assert state changes.
 		assert!(!EvmSystem::account_exists(&account_id));
@@ -100,10 +106,10 @@ fn remove_account_fails() {
 		let account_id = H160::from_str("1000000000000000000000000000000000000001").unwrap();
 
 		// Invoke the function under test.
-		assert_noop!(
+		assert_storage_noop!(assert_eq!(
 			EvmSystem::remove_account(&account_id),
-			Error::<Test>::AccountNotExist
-		);
+			AccountRemovalOutcome::DidNotExist
+		));
 	});
 }
 


### PR DESCRIPTION
* Add assert_total_issuance_invariant helper

* Add evm_system_removing_account_non_zero_balance test

* Fix removing account logic

* Undo redundant changes

* Redesign fix usage

* Undo try_mutate_exists_account_removed changes

* Rename Exists account removal status into Remains

* Improve docs

* Apply renaming at tests

* Use assert_storage_noop

* Remove rusttoolchain