### PR TITLE
Add missing `on_created_account` logic usage for `inc_account_nonce` at `pallet-evm-system`

### DIFF
--- a/frame/evm-system/src/lib.rs
+++ b/frame/evm-system/src/lib.rs
@@ -160,7 +160,16 @@ impl<T: Config> Pallet<T> {
 
 	/// Increment a particular account's nonce by 1.
 	pub fn inc_account_nonce(who: &<T as Config>::AccountId) {
-		Account::<T>::mutate(who, |a| a.nonce += <T as pallet::Config>::Index::one());
+		Account::<T>::mutate(who, |a| {
+			a.nonce += <T as Config>::Index::one();
+
+			// Meaning that account is being created.
+			if a.nonce == <T as Config>::Index::one()
+				&& a.data == <T as Config>::AccountData::default()
+			{
+				Self::on_created_account(who.clone());
+			}
+		});
 	}
 
 	/// Create an account.


### PR DESCRIPTION
Discovered during work on #140 