### PR TITLE
Properly handle `on_created_account` related to `inc_account_nonce` logic

### DIFF
--- a/frame/evm-system/src/lib.rs
+++ b/frame/evm-system/src/lib.rs
@@ -160,14 +160,21 @@ impl<T: Config> Pallet<T> {
 
 	/// Increment a particular account's nonce by 1.
 	pub fn inc_account_nonce(who: &<T as Config>::AccountId) {
-		Account::<T>::mutate(who, |a| {
-			a.nonce += <T as Config>::Index::one();
+		let is_new_account = Account::<T>::mutate_exists(who, |maybe_account| {
+			let is_new_account = maybe_account.is_none();
 
-			// Meaning that account is being created.
-			if !Self::account_exists(who) {
-				Self::on_created_account(who.clone());
-			}
+			let mut account = maybe_account.take().unwrap_or_default();
+			account.nonce += <T as Config>::Index::one();
+
+			*maybe_account = Some(account);
+
+			is_new_account
 		});
+
+		// Meaning that account is being created.
+		if is_new_account {
+			Self::on_created_account(who.clone());
+		}
 	}
 
 	/// Create an account.

--- a/frame/evm-system/src/lib.rs
+++ b/frame/evm-system/src/lib.rs
@@ -163,7 +163,7 @@ impl<T: Config> Pallet<T> {
 		let is_new_account = Account::<T>::mutate_exists(who, |maybe_account| {
 			let is_new_account = maybe_account.is_none();
 
-			let mut account = maybe_account.get_or_insert_default();
+			let account = maybe_account.get_or_insert_default();
 			account.nonce += <T as Config>::Index::one();
 
 			is_new_account

--- a/frame/evm-system/src/lib.rs
+++ b/frame/evm-system/src/lib.rs
@@ -160,13 +160,13 @@ impl<T: Config> Pallet<T> {
 
 	/// Increment a particular account's nonce by 1.
 	pub fn inc_account_nonce(who: &<T as Config>::AccountId) {
+		let is_account_existed = Self::account_exists(who);
+
 		Account::<T>::mutate(who, |a| {
 			a.nonce += <T as Config>::Index::one();
 
 			// Meaning that account is being created.
-			if a.nonce == <T as Config>::Index::one()
-				&& a.data == <T as Config>::AccountData::default()
-			{
+			if !is_account_existed {
 				Self::on_created_account(who.clone());
 			}
 		});

--- a/frame/evm-system/src/lib.rs
+++ b/frame/evm-system/src/lib.rs
@@ -160,16 +160,16 @@ impl<T: Config> Pallet<T> {
 
 	/// Increment a particular account's nonce by 1.
 	pub fn inc_account_nonce(who: &<T as Config>::AccountId) {
-		let is_account_existed = Self::account_exists(who);
+		let was_existed = Self::account_exists(who);
 
 		Account::<T>::mutate(who, |a| {
 			a.nonce += <T as Config>::Index::one();
-
-			// Meaning that account is being created.
-			if !is_account_existed {
-				Self::on_created_account(who.clone());
-			}
 		});
+
+		// Meaning that account is being created.
+		if !was_existed {
+			Self::on_created_account(who.clone());
+		}
 	}
 
 	/// Create an account.

--- a/frame/evm-system/src/lib.rs
+++ b/frame/evm-system/src/lib.rs
@@ -160,16 +160,14 @@ impl<T: Config> Pallet<T> {
 
 	/// Increment a particular account's nonce by 1.
 	pub fn inc_account_nonce(who: &<T as Config>::AccountId) {
-		let was_existed = Self::account_exists(who);
-
 		Account::<T>::mutate(who, |a| {
 			a.nonce += <T as Config>::Index::one();
-		});
 
-		// Meaning that account is being created.
-		if !was_existed {
-			Self::on_created_account(who.clone());
-		}
+			// Meaning that account is being created.
+			if !Self::account_exists(who) {
+				Self::on_created_account(who.clone());
+			}
+		});
 	}
 
 	/// Create an account.

--- a/frame/evm-system/src/lib.rs
+++ b/frame/evm-system/src/lib.rs
@@ -163,10 +163,8 @@ impl<T: Config> Pallet<T> {
 		let is_new_account = Account::<T>::mutate_exists(who, |maybe_account| {
 			let is_new_account = maybe_account.is_none();
 
-			let mut account = maybe_account.take().unwrap_or_default();
+			let mut account = maybe_account.get_or_insert_default();
 			account.nonce += <T as Config>::Index::one();
-
-			*maybe_account = Some(account);
 
 			is_new_account
 		});


### PR DESCRIPTION
Decided to rethink about  #147 and all conversations we had.

Suggest to move decision making logic to doing checks whether account was existed before or not instead of checking account data values inside `Account::<T>::mutate`