### PR TITLE
Rename remove_account to on_account_self_destruct at AccountProvider interface

### DIFF
--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -794,7 +794,7 @@ impl<T: Config> Pallet<T> {
 	pub fn remove_account(address: &H160) {
 		if <AccountCodes<T>>::contains_key(address) {
 			let account_id = T::AddressMapping::into_account_id(*address);
-			T::AccountProvider::remove_account(&account_id);
+			T::AccountProvider::on_account_self_destruct(&account_id);
 		}
 
 		<AccountCodes<T>>::remove(address);
@@ -1069,7 +1069,7 @@ impl<T: frame_system::Config> AccountProvider for NativeSystemAccountProvider<T>
 	fn create_account(who: &Self::AccountId) {
 		let _ = frame_system::Pallet::<T>::inc_sufficients(&who);
 	}
-	fn remove_account(who: &Self::AccountId) {
+	fn on_account_self_destruct(who: &Self::AccountId) {
 		let _ = frame_system::Pallet::<T>::dec_sufficients(&who);
 	}
 }

--- a/primitives/evm/src/account_provider.rs
+++ b/primitives/evm/src/account_provider.rs
@@ -26,10 +26,10 @@ pub trait AccountProvider {
 	///
 	/// The account associated with new created address EVM.
 	fn create_account(who: &Self::AccountId);
-	/// Removes an account from accounts records.
+	/// A hook on account affected by executing selfdestruct opcode.
 	///
-	/// The account associated with removed address from EVM.
-	fn remove_account(who: &Self::AccountId);
+	/// The account associated with affected address in EVM.
+	fn on_account_self_destruct(who: &Self::AccountId);
 	/// Return current account nonce value.
 	///
 	/// Used to represent account basic information in EVM format.


### PR DESCRIPTION
Partially apply https://github.com/humanode-network/frontier/pull/140