### PR TITLE
[backport] Add `CallOrCreateInfo` to `ValidatedTransaction` apply result. (#1099)

### DIFF
--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -42,7 +42,9 @@ use fp_evm::{
 use fp_storage::{EthereumStorageSchema, PALLET_ETHEREUM_SCHEMA};
 use frame_support::{
 	codec::{Decode, Encode, MaxEncodedLen},
-	dispatch::{DispatchInfo, DispatchResultWithPostInfo, Pays, PostDispatchInfo},
+	dispatch::{
+		DispatchErrorWithPostInfo, DispatchInfo, DispatchResultWithPostInfo, Pays, PostDispatchInfo,
+	},
 	scale_info::TypeInfo,
 	traits::{EnsureOrigin, Get, PalletInfoAccess, Time},
 	weights::Weight,
@@ -55,7 +57,7 @@ use sp_runtime::{
 	transaction_validity::{
 		InvalidTransaction, TransactionValidity, TransactionValidityError, ValidTransactionBuilder,
 	},
-	DispatchErrorWithPostInfo, RuntimeDebug, SaturatedConversion,
+	RuntimeDebug, SaturatedConversion,
 };
 use sp_std::{marker::PhantomData, prelude::*};
 
@@ -241,7 +243,7 @@ pub mod pallet {
 					Self::validate_transaction_in_block(source, &transaction).expect(
 						"pre-block transaction verification failed; the block cannot be built",
 					);
-					let r = Self::apply_validated_transaction(source, transaction)
+					let (r, _) = Self::apply_validated_transaction(source, transaction)
 						.expect("pre-block apply transaction failed; the block cannot be built");
 
 					weight = weight.saturating_add(r.actual_weight.unwrap_or_default());
@@ -290,7 +292,7 @@ pub mod pallet {
 				"pre log already exists; block is invalid",
 			);
 
-			Self::apply_validated_transaction(source, transaction)
+			Self::apply_validated_transaction(source, transaction).map(|(post_info, _)| post_info)
 		}
 	}
 
@@ -558,14 +560,14 @@ impl<T: Config> Pallet<T> {
 	fn apply_validated_transaction(
 		source: H160,
 		transaction: Transaction,
-	) -> DispatchResultWithPostInfo {
+	) -> Result<(PostDispatchInfo, CallOrCreateInfo), DispatchErrorWithPostInfo> {
 		let (to, _, info) = Self::execute(source, &transaction, None)?;
 
 		let pending = Pending::<T>::get();
 		let transaction_hash = transaction.hash();
 		let transaction_index = pending.len() as u32;
 
-		let (reason, status, weight_info, used_gas, dest, extra_data) = match info {
+		let (reason, status, weight_info, used_gas, dest, extra_data) = match info.clone() {
 			CallOrCreateInfo::Call(info) => (
 				info.exit_reason.clone(),
 				TransactionStatus {
@@ -680,24 +682,27 @@ impl<T: Config> Pallet<T> {
 			extra_data,
 		});
 
-		Ok(PostDispatchInfo {
-			actual_weight: {
-				let mut gas_to_weight = T::GasWeightMapping::gas_to_weight(
-					sp_std::cmp::max(
-						used_gas.standard.unique_saturated_into(),
-						used_gas.effective.unique_saturated_into(),
-					),
-					true,
-				);
-				if let Some(weight_info) = weight_info {
-					if let Some(proof_size_usage) = weight_info.proof_size_usage {
-						*gas_to_weight.proof_size_mut() = proof_size_usage;
+		Ok((
+			PostDispatchInfo {
+				actual_weight: {
+					let mut gas_to_weight = T::GasWeightMapping::gas_to_weight(
+						sp_std::cmp::max(
+							used_gas.standard.unique_saturated_into(),
+							used_gas.effective.unique_saturated_into(),
+						),
+						true,
+					);
+					if let Some(weight_info) = weight_info {
+						if let Some(proof_size_usage) = weight_info.proof_size_usage {
+							*gas_to_weight.proof_size_mut() = proof_size_usage;
+						}
 					}
-				}
-				Some(gas_to_weight)
+					Some(gas_to_weight)
+				},
+				pays_fee: Pays::No,
 			},
-			pays_fee: Pays::No,
-		})
+			info,
+		))
 	}
 
 	/// Get current block hash
@@ -710,10 +715,7 @@ impl<T: Config> Pallet<T> {
 		from: H160,
 		transaction: &Transaction,
 		config: Option<evm::Config>,
-	) -> Result<
-		(Option<H160>, Option<H160>, CallOrCreateInfo),
-		DispatchErrorWithPostInfo<PostDispatchInfo>,
-	> {
+	) -> Result<(Option<H160>, Option<H160>, CallOrCreateInfo), DispatchErrorWithPostInfo> {
 		let (
 			input,
 			value,
@@ -966,7 +968,10 @@ impl<T: Config> Pallet<T> {
 
 pub struct ValidatedTransaction<T>(PhantomData<T>);
 impl<T: Config> ValidatedTransactionT for ValidatedTransaction<T> {
-	fn apply(source: H160, transaction: Transaction) -> DispatchResultWithPostInfo {
+	fn apply(
+		source: H160,
+		transaction: Transaction,
+	) -> Result<(PostDispatchInfo, CallOrCreateInfo), DispatchErrorWithPostInfo> {
 		Pallet::<T>::apply_validated_transaction(source, transaction)
 	}
 }

--- a/primitives/ethereum/src/lib.rs
+++ b/primitives/ethereum/src/lib.rs
@@ -23,9 +23,10 @@ pub use ethereum::{
 	TransactionAction, TransactionV2 as Transaction,
 };
 use ethereum_types::{H160, H256, U256};
-use fp_evm::CheckEvmTransactionInput;
+use fp_evm::{CallOrCreateInfo, CheckEvmTransactionInput};
+use frame_support::dispatch::{DispatchErrorWithPostInfo, PostDispatchInfo};
 use scale_codec::{Decode, Encode};
-use sp_std::vec::Vec;
+use sp_std::{result::Result, vec::Vec};
 
 #[repr(u8)]
 #[derive(num_enum::FromPrimitive, num_enum::IntoPrimitive)]
@@ -44,7 +45,7 @@ pub trait ValidatedTransaction {
 	fn apply(
 		source: H160,
 		transaction: Transaction,
-	) -> frame_support::dispatch::DispatchResultWithPostInfo;
+	) -> Result<(PostDispatchInfo, CallOrCreateInfo), DispatchErrorWithPostInfo>;
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Encode, Decode)]


### PR DESCRIPTION
Discovered It would be great to backport this logic https://github.com/polkadot-evm/frontier/pull/1099 during the work on https://github.com/humanode-network/humanode/pull/1449.

Btw, the code is a part of `polkadot-v1.0.0` :)